### PR TITLE
Repeated biometry usage

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,5 +61,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api "com.wultra.android.powerauth:powerauth-sdk:1.5.3"
+    api "com.wultra.android.powerauth:powerauth-sdk:1.5.4"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
+            mavenCentral()
             jcenter()
         }
         dependencies {
@@ -60,5 +61,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api "io.getlime.security.powerauth:powerauth-android-sdk:1.5.1"
+    api "com.wultra.android.powerauth:powerauth-sdk:1.5.3"
 }

--- a/demoapp/App.tsx
+++ b/demoapp/App.tsx
@@ -396,6 +396,38 @@ export default class App extends Component<any, State> {
             }
           } }) }} />
 
+          <Text style={styles.titleText}>Grouped biometry authentication</Text>
+          <Button title="Test grouped biometry action" onPress={ async _ => {
+            
+            const auth = new PowerAuthAuthentication();
+            auth.usePossession = true;
+            auth.userPassword = null;
+            auth.useBiometry = true;
+            auth.biometryTitle = "Grouped authentication";
+            auth.biometryMessage = "One biometric authentication will be used for 2 operations.";
+            let ra;
+            try {
+              await PowerAuth.groupedBiometricAuthentication(auth, async (reusableAuth) => {
+                ra = reusableAuth;
+                console.log(ra);
+                try {
+                  const r1 = await PowerAuth.requestSignature(reusableAuth, "POST", "/pa/signature/validate", "{jsonbody: \"yes\"}");
+                  console.log(`Signature:\nKEY:${r1.key}\nVAL:${r1.value}`);
+                  const r2 = await PowerAuth.requestSignature(reusableAuth, "POST", "/pa/signature/validate", "{jsonbody: \"no\"}");
+                  console.log(`Signature:\nKEY:${r2.key}\nVAL:${r2.value}`);
+                  alert("Biometry authentication was used for 2 operations")
+                } catch (e) {
+                  alert(`Failed to reuse reusableAuth: ${e.code}`);
+                  this.printPAException(e);
+                }
+              })
+              console.log(ra);
+            } catch(e) {
+              alert(`Grouped biometry failed: ${e.code}`);
+              this.printPAException(e);
+            }
+           }} />
+
           <Text style={styles.titleText}>Validation</Text>
           <Button title="Parse activation code" onPress={ _ => { this.setState({ promptVisible: true, promptLabel: "Enter activation code", promptCallback: async code => {
             await sleep(100);

--- a/demoapp/App.tsx
+++ b/demoapp/App.tsx
@@ -405,23 +405,20 @@ export default class App extends Component<any, State> {
             auth.useBiometry = true;
             auth.biometryTitle = "Grouped authentication";
             auth.biometryMessage = "One biometric authentication will be used for 2 operations.";
-            let ra;
+            
             try {
               await PowerAuth.groupedBiometricAuthentication(auth, async (reusableAuth) => {
-                ra = reusableAuth;
-                console.log(ra);
                 try {
                   const r1 = await PowerAuth.requestSignature(reusableAuth, "POST", "/pa/signature/validate", "{jsonbody: \"yes\"}");
-                  console.log(`Signature:\nKEY:${r1.key}\nVAL:${r1.value}`);
+                  console.log(`r1 success`);
                   const r2 = await PowerAuth.requestSignature(reusableAuth, "POST", "/pa/signature/validate", "{jsonbody: \"no\"}");
-                  console.log(`Signature:\nKEY:${r2.key}\nVAL:${r2.value}`);
-                  alert("Biometry authentication was used for 2 operations")
+                  console.log(`r2 success`);
+                  alert(`Success`);
                 } catch (e) {
                   alert(`Failed to reuse reusableAuth: ${e.code}`);
                   this.printPAException(e);
                 }
-              })
-              console.log(ra);
+              });
             } catch(e) {
               alert(`Grouped biometry failed: ${e.code}`);
               this.printPAException(e);

--- a/demoapp/ios/Podfile
+++ b/demoapp/ios/Podfile
@@ -7,7 +7,6 @@ platform :ios, '10.0'
 target 'PowerAuthDemo' do
   config = use_native_modules!
   use_unimodules!
-  pod 'PowerAuth2', :git => 'https://github.com/wultra/powerauth-mobile-sdk.git', :branch => 'release/1.5.x', :submodules => true # TODO REMOVE ME BEFORE PRODUCTION!
   use_react_native!(:path => config["reactNativePath"])
 
   #pod 'react-native-powerauth-mobile-sdk', :path => '../node_modules/react-native-powerauth-mobile-sdk'

--- a/demoapp/ios/Podfile
+++ b/demoapp/ios/Podfile
@@ -7,6 +7,7 @@ platform :ios, '10.0'
 target 'PowerAuthDemo' do
   config = use_native_modules!
   use_unimodules!
+  pod 'PowerAuth2', :git => 'https://github.com/wultra/powerauth-mobile-sdk.git', :branch => 'release/1.5.x', :submodules => true # TODO REMOVE ME BEFORE PRODUCTION!
   use_react_native!(:path => config["reactNativePath"])
 
   #pod 'react-native-powerauth-mobile-sdk', :path => '../node_modules/react-native-powerauth-mobile-sdk'

--- a/demoapp/ios/Podfile.lock
+++ b/demoapp/ios/Podfile.lock
@@ -46,7 +46,7 @@ PODS:
     - React-jsi (= 0.64.0)
     - ReactCommon/turbomodule/core (= 0.64.0)
   - glog (0.3.5)
-  - PowerAuth2 (1.5.2)
+  - PowerAuth2 (1.5.3)
   - RCT-Folly (2020.01.13.00):
     - boost-for-react-native
     - DoubleConversion
@@ -241,7 +241,7 @@ PODS:
     - React-perflogger (= 0.64.0)
   - React-jsinspector (0.64.0)
   - react-native-powerauth-mobile-sdk (1.5.2):
-    - PowerAuth2 (= 1.5.2)
+    - PowerAuth2 (= 1.5.3)
     - React
   - React-perflogger (0.64.0)
   - React-RCTActionSheet (0.64.0):
@@ -350,6 +350,7 @@ DEPENDENCIES:
   - FBLazyVector (from `/Users/kober/dev/wultra/repos/react-native-powerauth-mobile-sdk/demoapp/node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `/Users/kober/dev/wultra/repos/react-native-powerauth-mobile-sdk/demoapp/node_modules/react-native/React/FBReactNativeSpec`)
   - glog (from `/Users/kober/dev/wultra/repos/react-native-powerauth-mobile-sdk/demoapp/node_modules/react-native/third-party-podspecs/glog.podspec`)
+  - PowerAuth2 (from `https://github.com/wultra/powerauth-mobile-sdk.git`, branch `release/1.5.x`)
   - RCT-Folly (from `/Users/kober/dev/wultra/repos/react-native-powerauth-mobile-sdk/demoapp/node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `/Users/kober/dev/wultra/repos/react-native-powerauth-mobile-sdk/demoapp/node_modules/react-native/Libraries/RCTRequired`)
   - RCTTypeSafety (from `/Users/kober/dev/wultra/repos/react-native-powerauth-mobile-sdk/demoapp/node_modules/react-native/Libraries/TypeSafety`)
@@ -397,7 +398,6 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - boost-for-react-native
-    - PowerAuth2
 
 EXTERNAL SOURCES:
   DoubleConversion:
@@ -434,6 +434,10 @@ EXTERNAL SOURCES:
     :path: "/Users/kober/dev/wultra/repos/react-native-powerauth-mobile-sdk/demoapp/node_modules/react-native/React/FBReactNativeSpec"
   glog:
     :podspec: "/Users/kober/dev/wultra/repos/react-native-powerauth-mobile-sdk/demoapp/node_modules/react-native/third-party-podspecs/glog.podspec"
+  PowerAuth2:
+    :branch: release/1.5.x
+    :git: https://github.com/wultra/powerauth-mobile-sdk.git
+    :submodules: true
   RCT-Folly:
     :podspec: "/Users/kober/dev/wultra/repos/react-native-powerauth-mobile-sdk/demoapp/node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTRequired:
@@ -517,6 +521,12 @@ EXTERNAL SOURCES:
   Yoga:
     :path: "/Users/kober/dev/wultra/repos/react-native-powerauth-mobile-sdk/demoapp/node_modules/react-native/ReactCommon/yoga"
 
+CHECKOUT OPTIONS:
+  PowerAuth2:
+    :commit: 06b618d8bb94ad0f0422df8993cdb7acc93d8ac3
+    :git: https://github.com/wultra/powerauth-mobile-sdk.git
+    :submodules: true
+
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
@@ -536,7 +546,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
   FBReactNativeSpec: 3d94589b80f946dbf29c7eb503c1230e69246c02
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
-  PowerAuth2: c6b221617d79b750fc22411232a79484f078827c
+  PowerAuth2: 1e700bf01f707d199e723dffedeacd86528b5a9d
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a
   RCTTypeSafety: 512728b73549e72ad7330b92f3d42936f2a4de5b
@@ -548,7 +558,7 @@ SPEC CHECKSUMS:
   React-jsi: 74341196d9547cbcbcfa4b3bbbf03af56431d5a1
   React-jsiexecutor: 06a9c77b56902ae7ffcdd7a4905f664adc5d237b
   React-jsinspector: 0ae35a37b20d5e031eb020a69cc5afdbd6406301
-  react-native-powerauth-mobile-sdk: 88a5a3b737b233861750fe5318175776d03469d9
+  react-native-powerauth-mobile-sdk: 200183aec9237da1620c6ea4ff13d6ec807ce484
   React-perflogger: 9c547d8f06b9bf00cb447f2b75e8d7f19b7e02af
   React-RCTActionSheet: 3080b6e12e0e1a5b313c8c0050699b5c794a1b11
   React-RCTAnimation: 3f96f21a497ae7dabf4d2f150ee43f906aaf516f
@@ -579,6 +589,6 @@ SPEC CHECKSUMS:
   UMTaskManagerInterface: 4e6c4c34a89512e2225d336154df1cb689226a29
   Yoga: 8c8436d4171c87504c648ae23b1d81242bdf3bbf
 
-PODFILE CHECKSUM: caca96ef220f47d2f984552e32125f1e0dda676a
+PODFILE CHECKSUM: 474071e2b8b6133e28d31b4b20d73cce5a2a7683
 
 COCOAPODS: 1.10.1

--- a/demoapp/ios/Podfile.lock
+++ b/demoapp/ios/Podfile.lock
@@ -46,7 +46,7 @@ PODS:
     - React-jsi (= 0.64.0)
     - ReactCommon/turbomodule/core (= 0.64.0)
   - glog (0.3.5)
-  - PowerAuth2 (1.5.3)
+  - PowerAuth2 (1.5.4)
   - RCT-Folly (2020.01.13.00):
     - boost-for-react-native
     - DoubleConversion
@@ -241,7 +241,7 @@ PODS:
     - React-perflogger (= 0.64.0)
   - React-jsinspector (0.64.0)
   - react-native-powerauth-mobile-sdk (1.5.2):
-    - PowerAuth2 (= 1.5.3)
+    - PowerAuth2 (= 1.5.4)
     - React
   - React-perflogger (0.64.0)
   - React-RCTActionSheet (0.64.0):
@@ -350,7 +350,6 @@ DEPENDENCIES:
   - FBLazyVector (from `/Users/kober/dev/wultra/repos/react-native-powerauth-mobile-sdk/demoapp/node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `/Users/kober/dev/wultra/repos/react-native-powerauth-mobile-sdk/demoapp/node_modules/react-native/React/FBReactNativeSpec`)
   - glog (from `/Users/kober/dev/wultra/repos/react-native-powerauth-mobile-sdk/demoapp/node_modules/react-native/third-party-podspecs/glog.podspec`)
-  - PowerAuth2 (from `https://github.com/wultra/powerauth-mobile-sdk.git`, branch `release/1.5.x`)
   - RCT-Folly (from `/Users/kober/dev/wultra/repos/react-native-powerauth-mobile-sdk/demoapp/node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `/Users/kober/dev/wultra/repos/react-native-powerauth-mobile-sdk/demoapp/node_modules/react-native/Libraries/RCTRequired`)
   - RCTTypeSafety (from `/Users/kober/dev/wultra/repos/react-native-powerauth-mobile-sdk/demoapp/node_modules/react-native/Libraries/TypeSafety`)
@@ -398,6 +397,7 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - boost-for-react-native
+    - PowerAuth2
 
 EXTERNAL SOURCES:
   DoubleConversion:
@@ -434,10 +434,6 @@ EXTERNAL SOURCES:
     :path: "/Users/kober/dev/wultra/repos/react-native-powerauth-mobile-sdk/demoapp/node_modules/react-native/React/FBReactNativeSpec"
   glog:
     :podspec: "/Users/kober/dev/wultra/repos/react-native-powerauth-mobile-sdk/demoapp/node_modules/react-native/third-party-podspecs/glog.podspec"
-  PowerAuth2:
-    :branch: release/1.5.x
-    :git: https://github.com/wultra/powerauth-mobile-sdk.git
-    :submodules: true
   RCT-Folly:
     :podspec: "/Users/kober/dev/wultra/repos/react-native-powerauth-mobile-sdk/demoapp/node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTRequired:
@@ -521,12 +517,6 @@ EXTERNAL SOURCES:
   Yoga:
     :path: "/Users/kober/dev/wultra/repos/react-native-powerauth-mobile-sdk/demoapp/node_modules/react-native/ReactCommon/yoga"
 
-CHECKOUT OPTIONS:
-  PowerAuth2:
-    :commit: 06b618d8bb94ad0f0422df8993cdb7acc93d8ac3
-    :git: https://github.com/wultra/powerauth-mobile-sdk.git
-    :submodules: true
-
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
@@ -546,7 +536,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
   FBReactNativeSpec: 3d94589b80f946dbf29c7eb503c1230e69246c02
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
-  PowerAuth2: 1e700bf01f707d199e723dffedeacd86528b5a9d
+  PowerAuth2: 7be73faab4e0900ec5606ccee0586b2fb4da88e1
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a
   RCTTypeSafety: 512728b73549e72ad7330b92f3d42936f2a4de5b
@@ -558,7 +548,7 @@ SPEC CHECKSUMS:
   React-jsi: 74341196d9547cbcbcfa4b3bbbf03af56431d5a1
   React-jsiexecutor: 06a9c77b56902ae7ffcdd7a4905f664adc5d237b
   React-jsinspector: 0ae35a37b20d5e031eb020a69cc5afdbd6406301
-  react-native-powerauth-mobile-sdk: 200183aec9237da1620c6ea4ff13d6ec807ce484
+  react-native-powerauth-mobile-sdk: 516a2a58bbf7aca6ab6f3e80b9da7827f11c79d4
   React-perflogger: 9c547d8f06b9bf00cb447f2b75e8d7f19b7e02af
   React-RCTActionSheet: 3080b6e12e0e1a5b313c8c0050699b5c794a1b11
   React-RCTAnimation: 3f96f21a497ae7dabf4d2f150ee43f906aaf516f
@@ -589,6 +579,6 @@ SPEC CHECKSUMS:
   UMTaskManagerInterface: 4e6c4c34a89512e2225d336154df1cb689226a29
   Yoga: 8c8436d4171c87504c648ae23b1d81242bdf3bbf
 
-PODFILE CHECKSUM: 474071e2b8b6133e28d31b4b20d73cce5a2a7683
+PODFILE CHECKSUM: caca96ef220f47d2f984552e32125f1e0dda676a
 
 COCOAPODS: 1.10.1

--- a/demoapp/package.json
+++ b/demoapp/package.json
@@ -3,6 +3,7 @@
     "start": "react-native start",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
+    "iosdevice": "react-native run-ios --device",
     "copymodule": "npm r react-native-powerauth-mobile-sdk && pushd .. && npm pack && file=$(ls | grep react-native-powerauth-mobile-sdk-*.tgz) && popd && npm i ../$file",
     "web": "expo start --web"
   },

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -9,7 +9,7 @@ target 'PowerAuth' do
   config = use_native_modules!
   use_react_native!(:path => config["reactNativePath"])
   
-  pod 'PowerAuth2', :git => 'https://github.com/wultra/powerauth-mobile-sdk.git', :branch => 'release/1.5.x', :submodules => true #pod 'PowerAuth2', '1.5.3'
+  pod 'PowerAuth2', '1.5.4'
   
 end
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -9,7 +9,7 @@ target 'PowerAuth' do
   config = use_native_modules!
   use_react_native!(:path => config["reactNativePath"])
   
-  pod 'PowerAuth2', '1.5.2'
+  pod 'PowerAuth2', :git => 'https://github.com/wultra/powerauth-mobile-sdk.git', :branch => 'release/1.5.x', :submodules => true #pod 'PowerAuth2', '1.5.3'
   
 end
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
     - React-jsi (= 0.64.0)
     - ReactCommon/turbomodule/core (= 0.64.0)
   - glog (0.3.5)
-  - PowerAuth2 (1.5.2)
+  - PowerAuth2 (1.5.3)
   - RCT-Folly (2020.01.13.00):
     - boost-for-react-native
     - DoubleConversion
@@ -275,7 +275,7 @@ DEPENDENCIES:
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
-  - PowerAuth2 (= 1.5.2)
+  - PowerAuth2 (from `https://github.com/wultra/powerauth-mobile-sdk.git`, branch `release/1.5.x`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
   - RCTTypeSafety (from `../node_modules/react-native/Libraries/TypeSafety`)
@@ -306,7 +306,6 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - boost-for-react-native
-    - PowerAuth2
 
 EXTERNAL SOURCES:
   DoubleConversion:
@@ -317,6 +316,10 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/React/FBReactNativeSpec"
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
+  PowerAuth2:
+    :branch: release/1.5.x
+    :git: https://github.com/wultra/powerauth-mobile-sdk.git
+    :submodules: true
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTRequired:
@@ -366,13 +369,19 @@ EXTERNAL SOURCES:
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
+CHECKOUT OPTIONS:
+  PowerAuth2:
+    :commit: 06b618d8bb94ad0f0422df8993cdb7acc93d8ac3
+    :git: https://github.com/wultra/powerauth-mobile-sdk.git
+    :submodules: true
+
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
   FBReactNativeSpec: 560149046c8124f3cb16e3176d47da45a383a51f
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
-  PowerAuth2: c6b221617d79b750fc22411232a79484f078827c
+  PowerAuth2: 1e700bf01f707d199e723dffedeacd86528b5a9d
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a
   RCTTypeSafety: 512728b73549e72ad7330b92f3d42936f2a4de5b
@@ -398,6 +407,6 @@ SPEC CHECKSUMS:
   ReactCommon: cfe2b7fd20e0dbd2d1185cd7d8f99633fbc5ff05
   Yoga: 8c8436d4171c87504c648ae23b1d81242bdf3bbf
 
-PODFILE CHECKSUM: 5740113f3dc79a4c6e212e701c14a6d3ec5e6c54
+PODFILE CHECKSUM: 2e363f21ce290218e86555ad00fd7e25f89afb2a
 
 COCOAPODS: 1.10.1

--- a/ios/PowerAuth/PowerAuth.m
+++ b/ios/PowerAuth/PowerAuth.m
@@ -659,6 +659,20 @@ RCT_EXPORT_METHOD(generateHeaderForToken:(nonnull NSString*)tokenName
     }
 }
 
+RCT_EXPORT_METHOD(authenticateWithBiometry:(nonnull NSString*)title // title is here only for API compatibility with android
+                  message:(nonnull NSString*)message
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+    [[PowerAuthSDK sharedInstance] authenticateUsingBiometryWithPrompt:message callback:^(PowerAuthAuthentication * authentication, NSError * error) {
+        if (authentication) {
+            resolve([authentication.overridenBiometryKey base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed]);
+        } else {
+            reject([self getErrorCodeFromError:error], error.localizedDescription, error);
+        }
+    }];
+}
+
 #pragma mark HELPER METHODS
 
 - (PowerAuthAuthentication *)constructAuthenticationFromDictionary:(NSDictionary*)dict
@@ -671,6 +685,9 @@ RCT_EXPORT_METHOD(generateHeaderForToken:(nonnull NSString*)tokenName
     }
     if (dict[@"biometryMessage"] != [NSNull null]) {
         auth.biometryPrompt = [RCTConvert NSString:dict[@"biometryMessage"]];
+    }
+    if ([dict.allKeys containsObject:@"biometryKey"] && dict[@"biometryKey"] != [NSNull null]) {
+        auth.overridenBiometryKey = [[NSData alloc] initWithBase64EncodedString:[RCTConvert NSString:dict[@"biometryKey"]] options:NSDataBase64DecodingIgnoreUnknownCharacters];
     }
     return auth;
 }

--- a/lib/PowerAuth.d.ts
+++ b/lib/PowerAuth.d.ts
@@ -215,7 +215,8 @@ declare class PowerAuth {
      * With this method, you can use 1 biometric authentication (dialog) for several operations.
      * Just use the `reusableAuthentication` variable inside the `groupedAuthenticationCalls` callback.
      *
-     * Note that after the `groupedAuthenticationCalls` is executed, the `reusableAuthentication` object is destroyed.
+     * Be aware, that you must not execute the next HTTP request signed with the same credentials when the previous one
+     * fails with the 401 HTTP status code. If you do, then you risk blocking the user's activation on the server.
      *
      * @param authentication authentication object
      * @param groupedAuthenticationCalls call that will use reusable authentication object

--- a/lib/PowerAuth.d.ts
+++ b/lib/PowerAuth.d.ts
@@ -209,6 +209,18 @@ declare class PowerAuth {
      * @param authentication Authentication used for recovery code confirmation
      */
     confirmRecoveryCode(recoveryCode: string, authentication: PowerAuthAuthentication): Promise<void>;
+    /**
+     * Helper method for grouping biometric authentications.
+     *
+     * With this method, you can use 1 biometric authentication (dialog) for several operations.
+     * Just use the `reusableAuthentication` variable inside the `groupedAuthenticationCalls` callback.
+     *
+     * Note that after the `groupedAuthenticationCalls` is executed, the `reusableAuthentication` object is destroyed.
+     *
+     * @param authentication authentication object
+     * @param groupedAuthenticationCalls call that will use reusable authentication object
+     */
+    groupedBiometricAuthentication(authentication: PowerAuthAuthentication, groupedAuthenticationCalls: (reusableAuthentication: PowerAuthAuthentication) => Promise<void>): Promise<void>;
     private wrapNativeCall;
 }
 declare const _default: PowerAuth;

--- a/lib/PowerAuth.js
+++ b/lib/PowerAuth.js
@@ -51,6 +51,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 };
 import { NativeModules, Platform } from 'react-native';
 import { PowerAuthError } from './model/PowerAuthError';
+import { __AuthenticationUtils } from "./internal/AuthenticationUtils";
 /**
  * Class used for the main interaction with the PowerAuth SDK components.
  */
@@ -153,7 +154,7 @@ var PowerAuth = /** @class */ (function () {
                     case 0:
                         _a = this.wrapNativeCall;
                         _c = (_b = this.nativeModule).removeActivationWithAuthentication;
-                        return [4 /*yield*/, authentication.process()];
+                        return [4 /*yield*/, __AuthenticationUtils.process(authentication)];
                     case 1: return [2 /*return*/, _a.apply(this, [_c.apply(_b, [_d.sent()])])];
                 }
             });
@@ -183,7 +184,7 @@ var PowerAuth = /** @class */ (function () {
                     case 0:
                         _a = this.wrapNativeCall;
                         _c = (_b = this.nativeModule).requestGetSignature;
-                        return [4 /*yield*/, authentication.process()];
+                        return [4 /*yield*/, __AuthenticationUtils.process(authentication)];
                     case 1: return [2 /*return*/, _a.apply(this, [_c.apply(_b, [_d.sent(), uriId, params !== null && params !== void 0 ? params : null])])];
                 }
             });
@@ -206,7 +207,7 @@ var PowerAuth = /** @class */ (function () {
                     case 0:
                         _a = this.wrapNativeCall;
                         _c = (_b = this.nativeModule).requestSignature;
-                        return [4 /*yield*/, authentication.process()];
+                        return [4 /*yield*/, __AuthenticationUtils.process(authentication)];
                     case 1: return [2 /*return*/, _a.apply(this, [_c.apply(_b, [_d.sent(), method, uriId, body])])];
                 }
             });
@@ -229,7 +230,7 @@ var PowerAuth = /** @class */ (function () {
                     case 0:
                         _a = this.wrapNativeCall;
                         _c = (_b = this.nativeModule).offlineSignature;
-                        return [4 /*yield*/, authentication.process()];
+                        return [4 /*yield*/, __AuthenticationUtils.process(authentication)];
                     case 1: return [2 /*return*/, _a.apply(this, [_c.apply(_b, [_d.sent(), uriId, body, nonce])])];
                 }
             });
@@ -323,7 +324,7 @@ var PowerAuth = /** @class */ (function () {
                     case 0:
                         _a = this.wrapNativeCall;
                         _c = (_b = this.nativeModule).fetchEncryptionKey;
-                        return [4 /*yield*/, authentication.process()];
+                        return [4 /*yield*/, __AuthenticationUtils.process(authentication)];
                     case 1: return [2 /*return*/, _a.apply(this, [_c.apply(_b, [_d.sent(), index])])];
                 }
             });
@@ -344,7 +345,7 @@ var PowerAuth = /** @class */ (function () {
                     case 0:
                         _a = this.wrapNativeCall;
                         _c = (_b = this.nativeModule).signDataWithDevicePrivateKey;
-                        return [4 /*yield*/, authentication.process()];
+                        return [4 /*yield*/, __AuthenticationUtils.process(authentication)];
                     case 1: return [2 /*return*/, _a.apply(this, [_c.apply(_b, [_d.sent(), data])])];
                 }
             });
@@ -379,7 +380,7 @@ var PowerAuth = /** @class */ (function () {
                     case 0:
                         _a = this.wrapNativeCall;
                         _c = (_b = this.nativeModule).activationRecoveryData;
-                        return [4 /*yield*/, authentication.process()];
+                        return [4 /*yield*/, __AuthenticationUtils.process(authentication)];
                     case 1: return [2 /*return*/, _a.apply(this, [_c.apply(_b, [_d.sent()])])];
                 }
             });
@@ -405,15 +406,64 @@ var PowerAuth = /** @class */ (function () {
                         _a = this.wrapNativeCall;
                         _c = (_b = this.nativeModule).confirmRecoveryCode;
                         _d = [recoveryCode];
-                        return [4 /*yield*/, authentication.process()];
+                        return [4 /*yield*/, __AuthenticationUtils.process(authentication)];
                     case 1: return [2 /*return*/, _a.apply(this, [_c.apply(_b, _d.concat([_e.sent()]))])];
+                }
+            });
+        });
+    };
+    /**
+     * Helper method for grouping biometric authentications.
+     *
+     * With this method, you can use 1 biometric authentication (dialog) for several operations.
+     * Just use the `reusableAuthentication` variable inside the `groupedAuthenticationCalls` callback.
+     *
+     * Note that after the `groupedAuthenticationCalls` is executed, the `reusableAuthentication` object is destroyed.
+     *
+     * @param authentication authentication object
+     * @param groupedAuthenticationCalls call that will use reusable authentication object
+     */
+    PowerAuth.prototype.groupedBiometricAuthentication = function (authentication, groupedAuthenticationCalls) {
+        return __awaiter(this, void 0, void 0, function () {
+            var reusable, _i, _a, prop, e_1;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
+                    case 0:
+                        if (authentication.useBiometry == false) {
+                            throw new PowerAuthError({ message: "Requesting biometric authentication, but `useBiometry` is set to false." });
+                        }
+                        _b.label = 1;
+                    case 1:
+                        _b.trys.push([1, 7, , 8]);
+                        return [4 /*yield*/, __AuthenticationUtils.process(authentication, true)];
+                    case 2:
+                        reusable = _b.sent();
+                        _b.label = 3;
+                    case 3:
+                        _b.trys.push([3, , 5, 6]);
+                        return [4 /*yield*/, groupedAuthenticationCalls(reusable)];
+                    case 4:
+                        _b.sent();
+                        return [3 /*break*/, 6];
+                    case 5:
+                        // Destroing the reusable object.
+                        for (_i = 0, _a = Object.getOwnPropertyNames(reusable); _i < _a.length; _i++) {
+                            prop = _a[_i];
+                            delete reusable[prop];
+                        }
+                        return [7 /*endfinally*/];
+                    case 6: return [3 /*break*/, 8];
+                    case 7:
+                        e_1 = _b.sent();
+                        throw new PowerAuthError(e_1);
+                    case 8: return [2 /*return*/];
                 }
             });
         });
     };
     PowerAuth.prototype.wrapNativeCall = function (nativePromise) {
         return __awaiter(this, void 0, void 0, function () {
-            var e_1;
+            var e_2;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
@@ -421,8 +471,8 @@ var PowerAuth = /** @class */ (function () {
                         return [4 /*yield*/, nativePromise];
                     case 1: return [2 /*return*/, _a.sent()];
                     case 2:
-                        e_1 = _a.sent();
-                        throw new PowerAuthError(e_1);
+                        e_2 = _a.sent();
+                        throw new PowerAuthError(e_2);
                     case 3: return [2 /*return*/];
                 }
             });

--- a/lib/PowerAuth.js
+++ b/lib/PowerAuth.js
@@ -418,44 +418,45 @@ var PowerAuth = /** @class */ (function () {
      * With this method, you can use 1 biometric authentication (dialog) for several operations.
      * Just use the `reusableAuthentication` variable inside the `groupedAuthenticationCalls` callback.
      *
-     * Note that after the `groupedAuthenticationCalls` is executed, the `reusableAuthentication` object is destroyed.
+     * Be aware, that you must not execute the next HTTP request signed with the same credentials when the previous one
+     * fails with the 401 HTTP status code. If you do, then you risk blocking the user's activation on the server.
      *
      * @param authentication authentication object
      * @param groupedAuthenticationCalls call that will use reusable authentication object
      */
     PowerAuth.prototype.groupedBiometricAuthentication = function (authentication, groupedAuthenticationCalls) {
         return __awaiter(this, void 0, void 0, function () {
-            var reusable, _i, _a, prop, e_1;
-            return __generator(this, function (_b) {
-                switch (_b.label) {
+            var reusable, e_1, e_2;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
                     case 0:
                         if (authentication.useBiometry == false) {
-                            throw new PowerAuthError({ message: "Requesting biometric authentication, but `useBiometry` is set to false." });
+                            throw new PowerAuthError(null, "Requesting biometric authentication, but `useBiometry` is set to false.");
                         }
-                        _b.label = 1;
+                        _a.label = 1;
                     case 1:
-                        _b.trys.push([1, 7, , 8]);
+                        _a.trys.push([1, 7, , 8]);
                         return [4 /*yield*/, __AuthenticationUtils.process(authentication, true)];
                     case 2:
-                        reusable = _b.sent();
-                        _b.label = 3;
+                        reusable = _a.sent();
+                        _a.label = 3;
                     case 3:
-                        _b.trys.push([3, , 5, 6]);
+                        _a.trys.push([3, 5, , 6]);
+                        // integrator defined chain of authorization calls with reusable authentication
                         return [4 /*yield*/, groupedAuthenticationCalls(reusable)];
                     case 4:
-                        _b.sent();
+                        // integrator defined chain of authorization calls with reusable authentication
+                        _a.sent();
                         return [3 /*break*/, 6];
                     case 5:
-                        // Destroing the reusable object.
-                        for (_i = 0, _a = Object.getOwnPropertyNames(reusable); _i < _a.length; _i++) {
-                            prop = _a[_i];
-                            delete reusable[prop];
-                        }
-                        return [7 /*endfinally*/];
+                        e_1 = _a.sent();
+                        // rethrow the error with information that the integrator should handle errors by himself
+                        throw new PowerAuthError(e_1, "Your 'groupedAuthenticationCalls' function threw an exception. Please make sure that you catch errors yourself.");
                     case 6: return [3 /*break*/, 8];
                     case 7:
-                        e_1 = _b.sent();
-                        throw new PowerAuthError(e_1);
+                        e_2 = _a.sent();
+                        // catching biometry authentication error and rethrowing it as PowerAuthError
+                        throw new PowerAuthError(e_2);
                     case 8: return [2 /*return*/];
                 }
             });
@@ -463,7 +464,7 @@ var PowerAuth = /** @class */ (function () {
     };
     PowerAuth.prototype.wrapNativeCall = function (nativePromise) {
         return __awaiter(this, void 0, void 0, function () {
-            var e_2;
+            var e_3;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
@@ -471,8 +472,8 @@ var PowerAuth = /** @class */ (function () {
                         return [4 /*yield*/, nativePromise];
                     case 1: return [2 /*return*/, _a.sent()];
                     case 2:
-                        e_2 = _a.sent();
-                        throw new PowerAuthError(e_2);
+                        e_3 = _a.sent();
+                        throw new PowerAuthError(e_3);
                     case 3: return [2 /*return*/];
                 }
             });

--- a/lib/PowerAuthTokenStore.js
+++ b/lib/PowerAuthTokenStore.js
@@ -50,6 +50,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 import { NativeModules } from 'react-native';
+import { __AuthenticationUtils } from './internal/AuthenticationUtils';
 var PowerAuthTokenStore = /** @class */ (function () {
     function PowerAuthTokenStore() {
     }
@@ -108,7 +109,7 @@ var PowerAuthTokenStore = /** @class */ (function () {
                     case 0:
                         _b = (_a = NativeModules.PowerAuth).requestAccessToken;
                         _c = [tokenName];
-                        return [4 /*yield*/, authentication.process()];
+                        return [4 /*yield*/, __AuthenticationUtils.process(authentication)];
                     case 1: return [2 /*return*/, _b.apply(_a, _c.concat([_d.sent()]))];
                 }
             });

--- a/lib/internal/AuthenticationUtils.js
+++ b/lib/internal/AuthenticationUtils.js
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+import { NativeModules, Platform } from 'react-native';
+import { PowerAuthAuthentication } from '../model/PowerAuthAuthentication';
+/**
+ * Internal authentication utility functions
+ */
+var __AuthenticationUtils = /** @class */ (function () {
+    function __AuthenticationUtils() {
+    }
+    /**
+     * Method will process `PowerAuthAuthentication` object are will return object according
+     * to its usage and platform.
+     *
+     * @param authentication authentication configuration
+     * @param makeReusable if the object should be reusable (for multiple authorizations)
+     * @returns configured authorization object
+     */
+    __AuthenticationUtils.process = function (authentication, makeBiometryReusable) {
+        var _a, _b;
+        if (makeBiometryReusable === void 0) { makeBiometryReusable = false; }
+        return __awaiter(this, void 0, void 0, function () {
+            var obj, key;
+            return __generator(this, function (_c) {
+                switch (_c.label) {
+                    case 0:
+                        obj = __assign({ biometryKey: null }, authentication);
+                        if (!(Platform.OS == "android" && authentication.useBiometry && obj.biometryKey == null)) return [3 /*break*/, 2];
+                        return [4 /*yield*/, NativeModules.PowerAuth.authenticateWithBiometry((_a = authentication.biometryTitle) !== null && _a !== void 0 ? _a : "??", (_b = authentication.biometryMessage) !== null && _b !== void 0 ? _b : "??")];
+                    case 1:
+                        key = _c.sent();
+                        obj.biometryKey = key;
+                        _c.label = 2;
+                    case 2: return [2 /*return*/, obj];
+                }
+            });
+        });
+    };
+    return __AuthenticationUtils;
+}());
+export { __AuthenticationUtils };
+var ReusablePowerAuthAuthentication = /** @class */ (function (_super) {
+    __extends(ReusablePowerAuthAuthentication, _super);
+    function ReusablePowerAuthAuthentication() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return ReusablePowerAuthAuthentication;
+}(PowerAuthAuthentication));

--- a/lib/internal/AuthenticationUtils.js
+++ b/lib/internal/AuthenticationUtils.js
@@ -82,29 +82,30 @@ var __AuthenticationUtils = /** @class */ (function () {
     function __AuthenticationUtils() {
     }
     /**
-     * Method will process `PowerAuthAuthentication` object are will return object according
-     * to its usage and platform.
+     * Method will process `PowerAuthAuthentication` object are will return object according to the platform.
      *
      * @param authentication authentication configuration
-     * @param makeReusable if the object should be reusable (for multiple authorizations)
+     * @param makeReusable if the object should be forced to be reusable
      * @returns configured authorization object
      */
-    __AuthenticationUtils.process = function (authentication, makeBiometryReusable) {
+    __AuthenticationUtils.process = function (authentication, makeReusable) {
         var _a, _b;
-        if (makeBiometryReusable === void 0) { makeBiometryReusable = false; }
+        if (makeReusable === void 0) { makeReusable = false; }
         return __awaiter(this, void 0, void 0, function () {
             var obj, key;
             return __generator(this, function (_c) {
                 switch (_c.label) {
                     case 0:
                         obj = __assign({ biometryKey: null }, authentication);
-                        if (!(Platform.OS == "android" && authentication.useBiometry && obj.biometryKey == null)) return [3 /*break*/, 2];
+                        if (!((Platform.OS == "android" && authentication.useBiometry && (obj.biometryKey == null || makeReusable)) || (Platform.OS == "ios" && makeReusable))) return [3 /*break*/, 2];
                         return [4 /*yield*/, NativeModules.PowerAuth.authenticateWithBiometry((_a = authentication.biometryTitle) !== null && _a !== void 0 ? _a : "??", (_b = authentication.biometryMessage) !== null && _b !== void 0 ? _b : "??")];
                     case 1:
                         key = _c.sent();
                         obj.biometryKey = key;
-                        _c.label = 2;
-                    case 2: return [2 /*return*/, obj];
+                        return [2 /*return*/, obj];
+                    case 2: 
+                    // no need for processing, just return original object
+                    return [2 /*return*/, authentication];
                 }
             });
         });

--- a/lib/model/PowerAuthAuthentication.d.ts
+++ b/lib/model/PowerAuthAuthentication.d.ts
@@ -14,7 +14,4 @@ export declare class PowerAuthAuthentication {
     biometryMessage: string;
     /** (Android only) Title of biometric prompt */
     biometryTitle: string;
-    /** Filled by the SDK. */
-    biometryKey: string;
-    process(): Promise<PowerAuthAuthentication>;
 }

--- a/lib/model/PowerAuthAuthentication.js
+++ b/lib/model/PowerAuthAuthentication.js
@@ -13,43 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __generator = (this && this.__generator) || function (thisArg, body) {
-    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
-    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
-    function verb(n) { return function (v) { return step([n, v]); }; }
-    function step(op) {
-        if (f) throw new TypeError("Generator is already executing.");
-        while (_) try {
-            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
-            if (y = 0, t) op = [op[0] & 2, t.value];
-            switch (op[0]) {
-                case 0: case 1: t = op; break;
-                case 4: _.label++; return { value: op[1], done: false };
-                case 5: _.label++; y = op[1]; op = [0]; continue;
-                case 7: op = _.ops.pop(); _.trys.pop(); continue;
-                default:
-                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
-                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
-                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
-                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
-                    if (t[2]) _.ops.pop();
-                    _.trys.pop(); continue;
-            }
-            op = body.call(thisArg, _);
-        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
-        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
-    }
-};
-import { NativeModules, Platform } from 'react-native';
 /**
  * Class representing a multi-factor authentication object.
  */
@@ -67,27 +30,7 @@ var PowerAuthAuthentication = /** @class */ (function () {
         this.biometryMessage = null;
         /** (Android only) Title of biometric prompt */
         this.biometryTitle = null;
-        /** Filled by the SDK. */
-        this.biometryKey = null;
     }
-    PowerAuthAuthentication.prototype.process = function () {
-        var _a, _b;
-        return __awaiter(this, void 0, void 0, function () {
-            var key;
-            return __generator(this, function (_c) {
-                switch (_c.label) {
-                    case 0:
-                        if (!(Platform.OS == "android" && this.useBiometry)) return [3 /*break*/, 2];
-                        return [4 /*yield*/, NativeModules.PowerAuth.authenticateWithBiometry((_a = this.biometryTitle) !== null && _a !== void 0 ? _a : "??", (_b = this.biometryMessage) !== null && _b !== void 0 ? _b : "??")];
-                    case 1:
-                        key = _c.sent();
-                        this.biometryKey = key;
-                        _c.label = 2;
-                    case 2: return [2 /*return*/, this];
-                }
-            });
-        });
-    };
     return PowerAuthAuthentication;
 }());
 export { PowerAuthAuthentication };

--- a/lib/model/PowerAuthError.d.ts
+++ b/lib/model/PowerAuthError.d.ts
@@ -14,7 +14,7 @@ export declare class PowerAuthError {
     domain?: string;
     /** Description of the error (iOS only). */
     description?: string;
-    constructor(exception: any);
+    constructor(exception: any, message?: string);
     print(): string;
 }
 export declare enum PowerAuthErrorCode {

--- a/lib/model/PowerAuthError.js
+++ b/lib/model/PowerAuthError.js
@@ -17,11 +17,12 @@
  * PowerAuthError is a wrapper error that is thrown by every API in this module.
  */
 var PowerAuthError = /** @class */ (function () {
-    function PowerAuthError(exception) {
+    function PowerAuthError(exception, message) {
+        if (message === void 0) { message = null; }
         var _a, _b, _c, _d, _e, _f;
         this.originalException = exception;
         this.code = (_a = exception === null || exception === void 0 ? void 0 : exception.code) !== null && _a !== void 0 ? _a : null;
-        this.message = (_b = exception === null || exception === void 0 ? void 0 : exception.message) !== null && _b !== void 0 ? _b : null;
+        this.message = (_b = message !== null && message !== void 0 ? message : exception === null || exception === void 0 ? void 0 : exception.message) !== null && _b !== void 0 ? _b : null;
         this.domain = (_c = exception === null || exception === void 0 ? void 0 : exception.domain) !== null && _c !== void 0 ? _c : null;
         this.errorData = (_d = exception === null || exception === void 0 ? void 0 : exception.userInfo) !== null && _d !== void 0 ? _d : null;
         this.description = (_f = (_e = exception === null || exception === void 0 ? void 0 : exception.userInfo) === null || _e === void 0 ? void 0 : _e.NSLocalizedDescription) !== null && _f !== void 0 ? _f : null;

--- a/react-native-powerauth-mobile-sdk.podspec
+++ b/react-native-powerauth-mobile-sdk.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React"
-  s.dependency "PowerAuth2", "1.5.3"
+  s.dependency "PowerAuth2", "1.5.4"
 end

--- a/react-native-powerauth-mobile-sdk.podspec
+++ b/react-native-powerauth-mobile-sdk.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React"
-  s.dependency "PowerAuth2", "1.5.2"
+  s.dependency "PowerAuth2", "1.5.3"
 end

--- a/src/PowerAuthTokenStore.ts
+++ b/src/PowerAuthTokenStore.ts
@@ -16,7 +16,8 @@
 
 import { PowerAuthAuthentication } from './model/PowerAuthAuthentication';
 import { NativeModules } from 'react-native';
-import { PowerAuthAuthorizationHttpHeader } from './model/PowerAuthAuthorizationHttpHeader'
+import { PowerAuthAuthorizationHttpHeader } from './model/PowerAuthAuthorizationHttpHeader';
+import { __AuthenticationUtils } from './internal/AuthenticationUtils';
 
 export class PowerAuthTokenStore {
 
@@ -68,7 +69,7 @@ export class PowerAuthTokenStore {
      * @return PowerAuth token with already generated header
      */
     static async requestAccessToken(tokenName: string, authentication: PowerAuthAuthentication): Promise<PowerAuthToken> {
-        return NativeModules.PowerAuth.requestAccessToken(tokenName, await authentication.process());
+        return NativeModules.PowerAuth.requestAccessToken(tokenName, await __AuthenticationUtils.process(authentication));
     }
 
     /**

--- a/src/internal/AuthenticationUtils.ts
+++ b/src/internal/AuthenticationUtils.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NativeModules, Platform } from 'react-native';
+import { PowerAuthAuthentication } from '../model/PowerAuthAuthentication'
+
+/**
+ * Internal authentication utility functions
+ */
+export class __AuthenticationUtils {
+
+    /**
+     * Method will process `PowerAuthAuthentication` object are will return object according 
+     * to its usage and platform.
+     * 
+     * @param authentication authentication configuration
+     * @param makeReusable if the object should be reusable (for multiple authorizations)
+     * @returns configured authorization object
+     */
+    static async process(authentication: PowerAuthAuthentication, makeBiometryReusable: boolean = false): Promise<PowerAuthAuthentication> {
+
+        // Setup reusable authentication object from given `authentication`. 
+        // BiometryKey property wil be preserved if the `authentication` object is already reusable.
+        let obj: ReusablePowerAuthAuthentication = { biometryKey: null, ...authentication };
+
+        // On android, we need to fetch the key for every biometric authentication.
+        // If the key is already set, use it (we're processing reusable biometric authentication)
+        if (Platform.OS == "android" && authentication.useBiometry && obj.biometryKey == null) {
+            const key = await NativeModules.PowerAuth.authenticateWithBiometry(authentication.biometryTitle ?? "??", authentication.biometryMessage ?? "??");
+            obj.biometryKey = key;
+        }
+        return obj;
+    }
+}
+
+class ReusablePowerAuthAuthentication extends PowerAuthAuthentication {
+    biometryKey: string;
+}

--- a/src/model/PowerAuthAuthentication.ts
+++ b/src/model/PowerAuthAuthentication.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { NativeModules, Platform } from 'react-native';
-
 /**
  * Class representing a multi-factor authentication object.
  */
@@ -33,16 +31,4 @@ import { NativeModules, Platform } from 'react-native';
 
     /** (Android only) Title of biometric prompt */
     biometryTitle: string = null;
-
-    /** Filled by the SDK. */
-    biometryKey: string = null;
-
-    async process(): Promise<PowerAuthAuthentication> {
-        if (Platform.OS == "android" && this.useBiometry) {
-            const key = await NativeModules.PowerAuth.authenticateWithBiometry(this.biometryTitle ?? "??", this.biometryMessage ?? "??");
-            this.biometryKey = key;
-        }
-        
-        return this;
-    }
 };

--- a/src/model/PowerAuthError.ts
+++ b/src/model/PowerAuthError.ts
@@ -33,10 +33,10 @@ export class PowerAuthError {
     /** Description of the error (iOS only). */
     description?: string;
 
-    constructor(exception: any) {
+    constructor(exception: any, message: string = null) {
         this.originalException = exception;
         this.code = exception?.code ?? null;
-        this.message = exception?.message ?? null;
+        this.message = message ?? exception?.message ?? null;
         this.domain = exception?.domain ?? null;
         this.errorData = exception?.userInfo ?? null;
         this.description = exception?.userInfo?.NSLocalizedDescription ?? null;


### PR DESCRIPTION
Integrates new features from PowerAuth Mobile SDK `1.5.4`

Resolves #28

Example usage:
```typescript
const auth = new PowerAuthAuthentication();
auth.usePossession = true;
auth.userPassword = null;
auth.useBiometry = true;
auth.biometryTitle = "Grouped authentication";
auth.biometryMessage = "One biometric authentication will be used for 2 operations.";

try {
  await PowerAuth.groupedBiometricAuthentication(auth, async (reusableAuth) => {
    try {
      const r1 = await PowerAuth.requestSignature(reusableAuth, "POST", "/pa/signature/validate", "{jsonbody: \"yes\"}");
      const r2 = await PowerAuth.requestSignature(reusableAuth, "POST", "/pa/signature/validate", "{jsonbody: \"no\"}");
      alert(`Success`);
    } catch (e) {
      console.log("error");
    }
  });
} catch(e) {
  console.log("error");
}
```