### PR TITLE
fix: specify requiresMainQueueSetup

### DIFF
--- a/ios/PowerAuth/PowerAuth.m
+++ b/ios/PowerAuth/PowerAuth.m
@@ -60,6 +60,11 @@ static inline id _CastObjectTo(id instance, Class desiredClass) {
 
 RCT_EXPORT_MODULE(PowerAuth);
 
++ (BOOL)requiresMainQueueSetup
+{
+    return NO;
+}
+
 #pragma mark - React methods
 
 RCT_REMAP_METHOD(isConfigured,


### PR DESCRIPTION
this removes the warning that is shown in console upon app start

```
Module PowerAuth requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.
```