### PR TITLE
Fix #119: Remove always true properties from PowerAuthToken

### DIFF
--- a/android/src/main/java/com/wultra/android/powerauth/reactnative/PowerAuthRNModule.java
+++ b/android/src/main/java/com/wultra/android/powerauth/reactnative/PowerAuthRNModule.java
@@ -852,8 +852,6 @@ public class PowerAuthRNModule extends ReactContextBaseJavaModule {
                     @Override
                     public void onGetTokenSucceeded(@NonNull PowerAuthToken token) {
                         WritableMap response = Arguments.createMap();
-                        response.putBoolean("isValid", token.isValid());
-                        response.putBoolean("canGenerateHeader", token.canGenerateHeader());
                         response.putString("tokenName", token.getTokenName());
                         response.putString("tokenIdentifier", token.getTokenIdentifier());
                         promise.resolve(response);
@@ -897,8 +895,6 @@ public class PowerAuthRNModule extends ReactContextBaseJavaModule {
                 PowerAuthToken token = sdk.getTokenStore().getLocalToken(context, tokenName);
                 if (token != null) {
                     WritableMap response = Arguments.createMap();
-                    response.putBoolean("isValid", token.isValid());
-                    response.putBoolean("canGenerateHeader", token.canGenerateHeader());
                     response.putString("tokenName", token.getTokenName());
                     response.putString("tokenIdentifier", token.getTokenIdentifier());
                     promise.resolve(response);

--- a/ios/PowerAuth/PowerAuth.m
+++ b/ios/PowerAuth/PowerAuth.m
@@ -742,8 +742,6 @@ RCT_REMAP_METHOD(requestAccessToken,
             [self processError:error with:reject];
         } else {
             resolve(@{
-                @"isValid": token.isValid ? @YES : @NO,
-                @"canGenerateHeader": token.canGenerateHeader ? @YES : @NO,
                 @"tokenName": token.tokenName,
                 @"tokenIdentifier": token.tokenIdentifier
             });
@@ -790,8 +788,6 @@ RCT_REMAP_METHOD(getLocalToken,
     PowerAuthToken* token = [[powerAuth tokenStore] localTokenWithName:tokenName];
     if (token) {
         resolve(@{
-            @"isValid": token.isValid ? @YES : @NO,
-            @"canGenerateHeader": token.canGenerateHeader ? @YES : @NO,
             @"tokenName": token.tokenName,
             @"tokenIdentifier": token.tokenIdentifier
         });

--- a/src/PowerAuthTokenStore.ts
+++ b/src/PowerAuthTokenStore.ts
@@ -111,22 +111,14 @@ export class PowerAuthTokenStore {
 
 export interface PowerAuthToken {
     /**
-     * Return true if this token object contains a valid token data.
-     */
-     isValid: boolean;
-    /**
      * Symbolic name of token or null if token contains an invalid data.
      */
-    tokenName?: string;
+    tokenName: string;
     /**
      * Return token's unique identifier. You normally don't need this value, but it may help
      * with application's debugging. The value identifies this token on PowerAuth server.
      *
      * Null if token contains an invalid data.
      */
-    tokenIdentifier?: string;
-    /**
-     * True if header can be generated.
-     */
-    canGenerateHeader: boolean;
+    tokenIdentifier: string;
 }


### PR DESCRIPTION
This PR removes always true properties from `PowerAuthToken` and fixes nullability for the rest of properties in the token object.