### PR TITLE
Implement debug features

### DIFF
--- a/android/src/main/java/com/wultra/android/powerauth/reactnative/PowerAuthRNModule.java
+++ b/android/src/main/java/com/wultra/android/powerauth/reactnative/PowerAuthRNModule.java
@@ -970,7 +970,9 @@ public class PowerAuthRNModule extends ReactContextBaseJavaModule {
         if (ac != null) {
             WritableMap response = Arguments.createMap();
             response.putString("activationCode", ac.activationCode);
-            response.putString("activationSignature", ac.activationSignature);
+            if (ac.activationSignature != null) {
+                response.putString("activationSignature", ac.activationSignature);
+            }
             promise.resolve(response);
         } else {
             promise.reject(EC_INVALID_ACTIVATION_CODE, "Invalid activation code.");
@@ -988,7 +990,9 @@ public class PowerAuthRNModule extends ReactContextBaseJavaModule {
         if (ac != null) {
             WritableMap response = Arguments.createMap();
             response.putString("activationCode", ac.activationCode);
-            response.putString("activationSignature", ac.activationSignature);
+            if (ac.activationSignature != null) {
+                response.putString("activationSignature", ac.activationSignature);
+            }
             promise.resolve(response);
         } else {
             promise.reject(EC_INVALID_RECOVERY_CODE, "Invalid recovery code.");

--- a/docs/Token-Based-Authentication.md
+++ b/docs/Token-Based-Authentication.md
@@ -76,3 +76,7 @@ try {
 ```
 
 Note that by removing tokens locally, you will lose control of the tokens stored on the server.
+
+## Read Next
+
+- [Troubleshooting](Troubleshooting.md)

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -1,0 +1,20 @@
+# Troubleshooting
+
+## Enable debug log
+
+In case you encounter a problem with this library, then try to turn-on a detailed debug log to provide a more information for the library developers:
+
+```javascript
+// Enable debug log with failed call to native function.
+PowerAuthDebug.traceNativeCodeCalls(true)
+// Trace all calls to native library
+PowerAuthDebug.traceNativeCodeCalls(true, true)
+```
+
+<!-- begin box warning -->
+The `PowerAuthDebug` class is effective only if global `__DEV__` constant is `true`. We don't want to log the sensitive information to the console in the production application.
+<!-- end -->
+
+## Read Next
+
+- [Sample Integration](Sample-Integration.md)

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -15,4 +15,5 @@
 
 **Additional Topics**
 
+- [Troubleshooting](Troubleshooting.md)
 - [Sample Integration](Sample-Integration.md)

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -10,5 +10,5 @@ target 'PowerAuth' do
   use_react_native!(
     :path => config["reactNativePath"]
   )
-  pod 'PowerAuth2', '1.7.1'  
+  pod 'PowerAuth2', '~> 1.7.3'  
 end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -11,9 +11,9 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.68.2)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - PowerAuth2 (1.7.1):
-    - PowerAuthCore (~> 1.7.1)
-  - PowerAuthCore (1.7.1)
+  - PowerAuth2 (1.7.3):
+    - PowerAuthCore (~> 1.7.3)
+  - PowerAuthCore (1.7.3)
   - RCT-Folly (2021.06.28.00-v2):
     - boost
     - DoubleConversion
@@ -294,7 +294,7 @@ DEPENDENCIES:
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
-  - PowerAuth2 (= 1.7.1)
+  - PowerAuth2 (~> 1.7.3)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
   - RCTTypeSafety (from `../node_modules/react-native/Libraries/TypeSafety`)
@@ -396,14 +396,14 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
-  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
+  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: a7a655862f6b09625d11c772296b01cd5164b648
   FBReactNativeSpec: 81ce99032d5b586fddd6a38d450f8595f7e04be4
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 3d02b25ca00c2d456734d0bcff864cbc62f6ae1a
-  PowerAuth2: f75ccf46ec84fd8ae2093f54680d2c3b3c4028e4
-  PowerAuthCore: f01d70990ceed8f26d3d01f21f856f7db8a7b8f9
-  RCT-Folly: b9d9fe1fc70114b751c076104e52f3b1b5e5a95a
+  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
+  PowerAuth2: d4d330c9b37dedc7e9645db02ea5a32889578b9e
+  PowerAuthCore: daeed9d22fce70cf1dfbabbff7a87837dada7e2d
+  RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
   RCTRequired: 3e917ea5377751094f38145fdece525aa90545a0
   RCTTypeSafety: c43c072a4bd60feb49a9570b0517892b4305c45e
   React: 176dd882de001854ced260fad41bb68a31aa4bd0
@@ -430,6 +430,6 @@ SPEC CHECKSUMS:
   ReactCommon: 095366164a276d91ea704ce53cb03825c487a3f2
   Yoga: 99652481fcd320aefa4a7ef90095b95acd181952
 
-PODFILE CHECKSUM: f7a7b8f95430897b1f9f89f130418d0057ea5094
+PODFILE CHECKSUM: 4dcedfce07447677e9d1e2fdfef997b159789b1a
 
 COCOAPODS: 1.11.3

--- a/ios/PowerAuth/PowerAuth.m
+++ b/ios/PowerAuth/PowerAuth.m
@@ -238,15 +238,14 @@ RCT_REMAP_METHOD(createActivation,
     
     [powerAuth createActivation:paActivation callback:^(PowerAuthActivationResult * _Nullable result, NSError * _Nullable error) {
         if (error == nil) {
-            NSDictionary *response = @{
+            resolve(_PatchNull(@{
                 @"activationFingerprint": result.activationFingerprint,
                 @"activationRecovery": result.activationRecovery ? @{
                     @"recoveryCode": result.activationRecovery.recoveryCode,
                     @"puk": result.activationRecovery.puk
                 } : [NSNull null],
                 @"customAttributes": result.customAttributes ? result.customAttributes : [NSNull null]
-            };
-            resolve(response);
+            }));
         } else {
             [self processError:error with:reject];
         }
@@ -320,7 +319,7 @@ RCT_REMAP_METHOD(removeActivationLocal,
 {
     PA_BLOCK_START
     [powerAuth removeActivationLocal];
-    resolve([NSNull null]);
+    resolve(nil);
     PA_BLOCK_END
 }
 
@@ -658,10 +657,10 @@ RCT_REMAP_METHOD(parseActivationCode,
 {
     PowerAuthActivationCode *ac = [PowerAuthActivationCodeUtil parseFromActivationCode:activationCode];
     if (ac) {
-        resolve(@{
+        resolve(_PatchNull(@{
             @"activationCode": ac.activationCode,
             @"activationSignature": ac.activationSignature ? ac.activationSignature : [NSNull null]
-        });
+        }));
     } else {
         reject(@"INVALID_ACTIVATION_CODE", @"Invalid activation code.", nil);
     }
@@ -682,10 +681,10 @@ RCT_REMAP_METHOD(parseRecoveryCode,
 {
     PowerAuthActivationCode *ac = [PowerAuthActivationCodeUtil parseFromRecoveryCode:recoveryCode];
     if (ac) {
-        resolve(@{
+        resolve(_PatchNull(@{
             @"activationCode": ac.activationCode,
             @"activationSignature": ac.activationSignature ? ac.activationSignature : [NSNull null]
-        });
+        }));
     } else {
         reject(@"INVALID_RECOVERY_CODE", @"Invalid recovery code.", nil);
     }
@@ -761,7 +760,7 @@ RCT_REMAP_METHOD(removeAccessToken,
     PA_BLOCK_START
     [[powerAuth tokenStore] removeAccessTokenWithName:tokenName completion:^(BOOL removed, NSError * error) {
         if (removed) {
-            resolve([NSNull null]);
+            resolve(nil);
         } else {
             [self processError:error with:reject];
         }
@@ -809,7 +808,7 @@ RCT_REMAP_METHOD(removeLocalToken,
 {
     PA_BLOCK_START
     [[powerAuth tokenStore] removeLocalTokenWithName:tokenName];
-    resolve([NSNull null]);
+    resolve(nil);
     PA_BLOCK_END
 }
 
@@ -820,7 +819,7 @@ RCT_REMAP_METHOD(removeAllLocalTokens,
 {
     PA_BLOCK_START
     [[powerAuth tokenStore] removeAllLocalTokens];
-    resolve([NSNull null]);
+    resolve(nil);
     PA_BLOCK_END
 }
 
@@ -893,6 +892,24 @@ RCT_REMAP_METHOD(generateHeaderForToken,
 
 
 #pragma mark - Helper methods
+
+/**
+ Patch nulls in object to undefined (e.g. remove keys with nulls)
+ */
+static id _PatchNull(id object) {
+    if (object == [NSNull null]) {
+        return nil;
+    }
+    if ([object isKindOfClass:[NSDictionary class]]) {
+        // Key-value dictionary
+        NSMutableDictionary * newObject = [object mutableCopy];
+        [(NSDictionary*)object enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL * stop) {
+            newObject[key] = _PatchNull(value);
+        }];
+        return newObject;
+    }
+    return object;
+}
 
 /// Method gets PowerAuthSDK instance from instance register and call `callback` with given object.
 /// In case that there's no such instnace, or instanceId is invalid, then calls reject promise with a failure.

--- a/react-native-powerauth-mobile-sdk.podspec
+++ b/react-native-powerauth-mobile-sdk.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React"
-  s.dependency "PowerAuth2", "~> 1.7.1"
+  s.dependency "PowerAuth2", "~> 1.7.3"
 end

--- a/scripts/update-apps.sh
+++ b/scripts/update-apps.sh
@@ -18,16 +18,22 @@ esac
 
 function LIB_PACKAGE
 {
+
+    PUSH_DIR "$SRC"
+
+    LOG_LINE
+    LOG 'Compiling typescript'
+    LOG_LINE
+
+    tsc -b
+    
     LOG_LINE
     LOG 'Building library archive'
     LOG_LINE
 
-    PUSH_DIR "$SRC"
-
     local file=( ${LIB}-*.tgz )
     [[ -f "$file" ]] && $RM ${LIB}-*.tgz
-    
-    tsc -b
+
     npm pack
     LIB_ARCHIVE=$(ls | grep ${LIB}-*.tgz)
     [[ -z "$LIB_ARCHIVE" ]] && FAILURE "npm pack did not produce library archive"

--- a/src/PowerAuth.ts
+++ b/src/PowerAuth.ts
@@ -26,7 +26,7 @@ import { PowerAuthCreateActivationResult } from './model/PowerAuthCreateActivati
 import { PowerAuthActivation } from './model/PowerAuthActivation';
 import { PowerAuthBiometryInfo } from './model/PowerAuthBiometryInfo';
 import { PowerAuthRecoveryActivationData } from './model/PowerAuthRecoveryActivationData';
-import { PowerAuthError } from './model/PowerAuthError';
+import { PowerAuthError, PowerAuthErrorCode } from './model/PowerAuthError';
 import { PowerAuthConfirmRecoveryCodeDataResult} from './model/PowerAuthConfirmRecoveryCodeDataResult';
 import { __NativeWrapper } from "./internal/NativeWrapper";
 import { PowerAuthTokenStore } from "./PowerAuthTokenStore"
@@ -78,7 +78,7 @@ export class PowerAuth {
      * If this PowerAuth instance was configured.
      */
     async isConfigured(): Promise<boolean> {
-        return this.wrapper.call("isConfigured");
+        return this.wrapper.callBool("isConfigured");
     }
 
     /**
@@ -125,7 +125,7 @@ export class PowerAuth {
         this.clientConfiguration = clientConfiguration
         this.biometryConfiguration = biometryConfiguration
         this.keychainConfiguration = keychainConfiguration
-        return this.wrapper.call("configure", configuration, clientConfiguration, biometryConfiguration, keychainConfiguration)
+        return this.wrapper.callBool("configure", configuration, clientConfiguration, biometryConfiguration, keychainConfiguration)
     }
 
     /** 
@@ -136,7 +136,7 @@ export class PowerAuth {
         this.clientConfiguration = null
         this.biometryConfiguration = null
         this.keychainConfiguration = null
-        return this.wrapper.call("deconfigure");
+        return this.wrapper.callBool("deconfigure");
     }
 
     /**
@@ -145,7 +145,7 @@ export class PowerAuth {
      * @returns true if there is a valid activation, false otherwise.
      */
     hasValidActivation(): Promise<boolean> {
-        return this.wrapper.call("hasValidActivation");
+        return this.wrapper.callBool("hasValidActivation");
     }
 
     /**
@@ -154,7 +154,7 @@ export class PowerAuth {
      * @return true if activation process can be started, false otherwise.
      */
     canStartActivation(): Promise<boolean> {
-        return this.wrapper.call("canStartActivation");
+        return this.wrapper.callBool("canStartActivation");
     }
 
     /**
@@ -163,7 +163,7 @@ export class PowerAuth {
      * @return true if there is a pending activation, false otherwise.
      */
     hasPendingActivation(): Promise<boolean> {
-        return this.wrapper.call("hasPendingActivation");
+        return this.wrapper.callBool("hasPendingActivation");
     }
 
     /**
@@ -285,7 +285,7 @@ export class PowerAuth {
      * @param masterKey If `true`, then master server public key is used for validation, otherwise personalized server's public key.
      */
     verifyServerSignedData(data: string, signature: string, masterKey: boolean): Promise<boolean> {
-        return this.wrapper.call("verifyServerSignedData", data, signature, masterKey);
+        return this.wrapper.callBool("verifyServerSignedData", data, signature, masterKey);
     }
 
     /**
@@ -310,7 +310,7 @@ export class PowerAuth {
      @return Returns true in case password was changed without error, NO otherwise.
      */
     unsafeChangePassword(oldPassword: string, newPassword: string): Promise<boolean> {
-        return this.wrapper.call("unsafeChangePassword", oldPassword, newPassword);
+        return this.wrapper.callBool("unsafeChangePassword", oldPassword, newPassword);
     }
 
     /**
@@ -334,7 +334,7 @@ export class PowerAuth {
      * This method returns the information about the key value being present in keychain.
      */
     hasBiometryFactor(): Promise<boolean> {
-        return this.wrapper.call("hasBiometryFactor");
+        return this.wrapper.callBool("hasBiometryFactor");
     }
 
     /**
@@ -343,7 +343,7 @@ export class PowerAuth {
      * @return true if the key was successfully removed, NO otherwise.
      */
     removeBiometryFactor(): Promise<boolean> {
-        return this.wrapper.call("removeBiometryFactor");
+        return this.wrapper.callBool("removeBiometryFactor");
     }
 
     /**
@@ -396,7 +396,7 @@ export class PowerAuth {
      * Returns YES if underlying session contains an activation recovery data.
      */
     hasActivationRecoveryData(): Promise<boolean> {
-        return this.wrapper.call("hasActivationRecoveryData");
+        return this.wrapper.callBool("hasActivationRecoveryData");
     }
 
     /**

--- a/src/PowerAuth.ts
+++ b/src/PowerAuth.ts
@@ -40,22 +40,22 @@ export class PowerAuth {
      * Configuration used to configure this instance of class. Note that modifying this property has no effect, but the
      * stored object is useful for the debugging purposes.
      */
-    configuration?: PowerAuthConfiguration | null = null
+    configuration?: PowerAuthConfiguration
     /**
      * Client configuration used to configure this instance of class. Note that modifying this property has no effect, but the
      * stored object is useful for the debugging purposes.
      */
-    clientConfiguration?: PowerAuthClientConfiguration | null = null
+    clientConfiguration?: PowerAuthClientConfiguration
     /**
      * Biometry configuration used to configure this instance of class. Note that modifying this property has no effect, but the
      * stored object is useful for the debugging purposes.
      */
-    biometryConfiguration?: PowerAuthBiometryConfiguration | null = null
+    biometryConfiguration?: PowerAuthBiometryConfiguration
     /**
      * Keychain configuration used to configure this instance of class. Note that modifying this property has no effect, but the
      * stored object is useful for the debugging purposes.
      */
-    keychainConfiguration?: PowerAuthKeychainConfiguration | null = null
+    keychainConfiguration?: PowerAuthKeychainConfiguration
 
     /**
      * Object for managing access tokens.
@@ -85,9 +85,9 @@ export class PowerAuth {
      * Prepares the PowerAuth instance with an advanced configuration. The method needs to be called before before any other method.
      * 
      * @param configuration Configuration object with basic parameters for `PowerAuth` class.
-     * @param clientConfiguration  Configuration for internal HTTP client. If `null` is provided, then `PowerAuthClientConfiguration.default()` is used.
-     * @param biometryConfiguration Biometry configuration. If `null` is provided, then `PowerAuthBiometryConfiguration.default()` is used.
-     * @param keychainConfiguration Configuration for internal keychain storage. If `null` is provided, then `PowerAuthKeychainConfiguration.default()` is used.
+     * @param clientConfiguration  Configuration for internal HTTP client. If `undefined` is provided, then `PowerAuthClientConfiguration.default()` is used.
+     * @param biometryConfiguration Biometry configuration. If `undefined` is provided, then `PowerAuthBiometryConfiguration.default()` is used.
+     * @param keychainConfiguration Configuration for internal keychain storage. If `undefined` is provided, then `PowerAuthKeychainConfiguration.default()` is used.
      */
     configure(configuration: PowerAuthConfiguration, clientConfiguration?: PowerAuthClientConfiguration, biometryConfiguration?: PowerAuthBiometryConfiguration, keychainConfiguration?: PowerAuthKeychainConfiguration): Promise<boolean>;
 
@@ -132,10 +132,10 @@ export class PowerAuth {
      * Deconfigures the instance
      */
     deconfigure(): Promise<boolean> {
-        this.configuration = null
-        this.clientConfiguration = null
-        this.biometryConfiguration = null
-        this.keychainConfiguration = null
+        this.configuration = undefined
+        this.clientConfiguration = undefined
+        this.biometryConfiguration = undefined
+        this.keychainConfiguration = undefined
         return NativeWrapper.thisCallBool("deconfigure", this.instanceId);
     }
 
@@ -151,7 +151,7 @@ export class PowerAuth {
     /**
      * Check if it is possible to start an activation process.
      * 
-     * @return true if activation process can be started, false otherwise.
+     * @returns true if activation process can be started, false otherwise.
      */
     canStartActivation(): Promise<boolean> {
         return NativeWrapper.thisCallBool("canStartActivation", this.instanceId);
@@ -160,7 +160,7 @@ export class PowerAuth {
     /**
      * Checks if there is a pending activation (activation in progress).
      * 
-     * @return true if there is a pending activation, false otherwise.
+     * @returns true if there is a pending activation, false otherwise.
      */
     hasPendingActivation(): Promise<boolean> {
         return NativeWrapper.thisCallBool("hasPendingActivation", this.instanceId);
@@ -175,7 +175,7 @@ export class PowerAuth {
      * - `/pa/upgrade/commit` - (optional) in case that protocol upgrade is required.
      * - `/pa/signature/validate` - (optional) as a prevention to local counter desynchronization.
      * 
-     * @return A promise with activation status result - it contains status information in case of success and error in case of failure.
+     * @returns A promise with activation status result - it contains status information in case of success and error in case of failure.
      */
     fetchActivationStatus(): Promise<PowerAuthActivationStatus> {
         return NativeWrapper.thisCall("fetchActivationStatus", this.instanceId);
@@ -200,17 +200,17 @@ export class PowerAuth {
     }
 
     /**
-     * Activation identifier or null if object has no valid activation.
+     * Activation identifier or undefined if object has no valid activation.
      */
-    getActivationIdentifier(): Promise<string> {
-        return NativeWrapper.thisCall("activationIdentifier", this.instanceId);
+    getActivationIdentifier(): Promise<string | undefined> {
+        return NativeWrapper.thisCallNull("activationIdentifier", this.instanceId);
     }
 
     /**
-     * Fingerprint calculated from device's public key or null if object has no valid activation.
+     * Fingerprint calculated from device's public key or undefined if object has no valid activation.
      */
-    getActivationFingerprint(): Promise<string> {
-        return NativeWrapper.thisCall("activationFingerprint", this.instanceId);
+    getActivationFingerprint(): Promise<string | undefined> {
+        return NativeWrapper.thisCallNull("activationFingerprint", this.instanceId);
     }
 
     /**
@@ -241,10 +241,10 @@ export class PowerAuth {
      * @param authentication An authentication instance specifying what factors should be used to sign the request.
      * @param uriId URI identifier.
      * @param params HTTP query params.
-     * @return HTTP header with PowerAuth authorization signature
+     * @returns HTTP header with PowerAuth authorization signature
      */
     async requestGetSignature(authentication: PowerAuthAuthentication, uriId: string, params?: any): Promise<PowerAuthAuthorizationHttpHeader> {
-        return NativeWrapper.thisCall("requestGetSignature", this.instanceId, await this.authenticate(authentication), uriId, params ?? null);
+        return NativeWrapper.thisCall("requestGetSignature", this.instanceId, await this.authenticate(authentication), uriId, params ?? undefined);
     }
 
     /**
@@ -256,7 +256,7 @@ export class PowerAuth {
      * @param method HTTP method used for the signature computation.
      * @param uriId URI identifier.
      * @param body HTTP request body.
-     * @return HTTP header with PowerAuth authorization signature.
+     * @returns HTTP header with PowerAuth authorization signature.
      */
     async requestSignature(authentication: PowerAuthAuthentication, method: string, uriId: string, body?: string): Promise<PowerAuthAuthorizationHttpHeader> {
         return NativeWrapper.thisCall("requestSignature", this.instanceId, await this.authenticate(authentication), method, uriId, body);
@@ -271,7 +271,7 @@ export class PowerAuth {
      * @param uriId URI identifier.
      * @param body HTTP request body.
      * @param nonce NONCE in Base64 format.
-     * @return String representing a calculated signature for all involved factors.
+     * @returns String representing a calculated signature for all involved factors.
      */
     async offlineSignature(authentication: PowerAuthAuthentication, uriId: string, nonce: string, body?: string): Promise<string> {
         return NativeWrapper.thisCall("offlineSignature", this.instanceId, await this.authenticate(authentication), uriId, body, nonce);
@@ -307,7 +307,7 @@ export class PowerAuth {
  
      @param oldPassword Old password, currently set to store the data.
      @param newPassword New password, to be set in case authentication with old password passes.
-     @return Returns true in case password was changed without error, NO otherwise.
+     @returns Returns true in case password was changed without error, false otherwise.
      */
     unsafeChangePassword(oldPassword: string, newPassword: string): Promise<boolean> {
         return NativeWrapper.thisCallBool("unsafeChangePassword", this.instanceId, oldPassword, newPassword);
@@ -340,7 +340,7 @@ export class PowerAuth {
     /**
      * Remove the biometry related factor key.
      * 
-     * @return true if the key was successfully removed, NO otherwise.
+     * @returns true if the key was successfully removed, false otherwise.
      */
     removeBiometryFactor(): Promise<boolean> {
         return NativeWrapper.thisCallBool("removeBiometryFactor", this.instanceId);
@@ -444,10 +444,10 @@ export class PowerAuth {
      */
     async groupedBiometricAuthentication(authentication: PowerAuthAuthentication, groupedAuthenticationCalls: (reusableAuthentication: PowerAuthAuthentication) => Promise<void>): Promise<void> {
         if (!await this.isConfigured()) {
-            throw new PowerAuthError(null, "Instance is not configured", PowerAuthErrorCode.INSTANCE_NOT_CONFIGURED);
+            throw new PowerAuthError(undefined, "Instance is not configured", PowerAuthErrorCode.INSTANCE_NOT_CONFIGURED);
         }
         if (authentication.useBiometry == false) {
-            throw new PowerAuthError(null, "Requesting biometric authentication, but `useBiometry` is set to false.");
+            throw new PowerAuthError(undefined, "Requesting biometric authentication, but `useBiometry` is set to false.");
         }
         try {
             const reusable = await this.authenticate(authentication, true);

--- a/src/PowerAuthActivationCodeUtil.ts
+++ b/src/PowerAuthActivationCodeUtil.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { __NativeWrapper } from "./internal/NativeWrapper";
+import { NativeWrapper } from "./internal/NativeWrapper";
 
 /**
  * The `PowerAuthActivationCodeUtil` provides various set of methods for parsing and validating
@@ -50,7 +50,7 @@ import { __NativeWrapper } from "./internal/NativeWrapper";
      * @throws error when not valid 
      */
     static parseActivationCode(activationCode: string): Promise<PowerAuthActivationCode> {
-        return __NativeWrapper.call("parseActivationCode", activationCode);
+        return NativeWrapper.staticCall("parseActivationCode", activationCode);
     }
 
     /**
@@ -61,7 +61,7 @@ import { __NativeWrapper } from "./internal/NativeWrapper";
      * @throws error when not valid 
      */
     static parseRecoveryCode(recoveryCode: string): Promise<PowerAuthActivationCode> {
-        return __NativeWrapper.call("parseRecoveryCode", recoveryCode);
+        return NativeWrapper.staticCall("parseRecoveryCode", recoveryCode);
     }
 
     /**
@@ -69,7 +69,7 @@ import { __NativeWrapper } from "./internal/NativeWrapper";
      * You can use this method to validate a whole user-typed activation code at once.
      */
     static validateActivationCode(activationCode: string): Promise<boolean> {
-        return __NativeWrapper.call("validateActivationCode", activationCode);
+        return NativeWrapper.staticCall("validateActivationCode", activationCode);
     }
 
     /**
@@ -77,7 +77,7 @@ import { __NativeWrapper } from "./internal/NativeWrapper";
      * a whole user-typed recovery code at once. The input code may contain "R:" prefix, if code is scanned from QR code.
      */
     static validateRecoveryCode(recoveryCode: string): Promise<boolean> {
-        return __NativeWrapper.call("validateRecoveryCode", recoveryCode);
+        return NativeWrapper.staticCall("validateRecoveryCode", recoveryCode);
     }
 
     /**
@@ -85,7 +85,7 @@ import { __NativeWrapper } from "./internal/NativeWrapper";
      * a whole user-typed recovery PUK at once. In current version, only 10 digits long string is considered as a valid PUK.
      */
     static validateRecoveryPuk(puk: string): Promise<boolean> {
-        return __NativeWrapper.call("validateRecoveryPuk", puk);
+        return NativeWrapper.staticCall("validateRecoveryPuk", puk);
     }
 
     /**
@@ -93,7 +93,7 @@ import { __NativeWrapper } from "./internal/NativeWrapper";
      * The method strictly checks whether the character is from [A-Z2-7] characters range.
      */
     static validateTypedCharacter(character: number): Promise<boolean> {
-        return __NativeWrapper.call("validateTypedCharacter", character);
+        return NativeWrapper.staticCall("validateTypedCharacter", character);
     }
 
     /**
@@ -107,7 +107,7 @@ import { __NativeWrapper } from "./internal/NativeWrapper";
      * - '1' is corrected to 'I'
      */
     static correctTypedCharacter(character: number): Promise<number> {
-        return __NativeWrapper.call("correctTypedCharacter", character);
+        return NativeWrapper.staticCall("correctTypedCharacter", character);
     }
 }
 

--- a/src/PowerAuthActivationCodeUtil.ts
+++ b/src/PowerAuthActivationCodeUtil.ts
@@ -46,7 +46,7 @@ import { NativeWrapper } from "./internal/NativeWrapper";
      * Parses an input |activationCode| (which may or may not contain an optional signature) and returns PowerAuthOtp 
      * object filled with valid data. The method doesn't perform an auto-correction, so the provided code must be valid.
      * 
-     * @return Activation code object
+     * @returns Activation code object
      * @throws error when not valid 
      */
     static parseActivationCode(activationCode: string): Promise<PowerAuthActivationCode> {
@@ -57,7 +57,7 @@ import { NativeWrapper } from "./internal/NativeWrapper";
      * Parses an input |recoveryCode| (which may or may not contain an optional "R:" prefix) and returns PowerAuthOtp 
      * object filled with valid data. The method doesn't perform an auto-correction, so the provided code must be valid.
      * 
-     * @return Activation code object
+     * @returns Activation code object
      * @throws error when not valid 
      */
     static parseRecoveryCode(recoveryCode: string): Promise<PowerAuthActivationCode> {

--- a/src/PowerAuthDebug.ts
+++ b/src/PowerAuthDebug.ts
@@ -1,0 +1,58 @@
+//
+// Copyright 2022 Wultra s.r.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { PowerAuthError } from "./index";
+import { NativeWrapper } from "./internal/NativeWrapper";
+
+/**
+ * The `PowerAuthDebug` class provides a various functionality that can
+ * help application develoepr with debugging the problem with React Native PowerAuth mobile SDK.
+ */
+export class PowerAuthDebug {
+    /**
+     * Enable or disable detailed log with calls to native code. Be aware that this feature is
+     * effective only if global __DEV__ constant is `true`.
+     * @param traceFailure If set to `true`, then SDK will print a detailed error if native call fails.
+     * @param traceEachCall If set to `true`, then SDK will print a detailed information about each call to the native code.
+     */
+    static traceNativeCodeCalls(traceFailure: boolean, traceEachCall: boolean = false) {
+        if (__DEV__) {
+            NativeWrapper.setDebugFeatures(traceFailure, traceEachCall)
+        }
+    }
+
+    /**
+     * Function converts any error into human readable string.
+     * @param error Error to descrive.
+     * @returns Error translated to human readable string.
+     */
+    static describeError(error: any): string {
+        if (typeof error === 'string') {
+            return error
+        }
+        if (error instanceof PowerAuthError) {
+            const components = [ 'PowerAuthError' ]
+            if (error.code) components.push(error.code)
+            if (error.message) components.push(error.message)
+            if (error.originalException) components.push(`Reason = { ${this.describeError(error.originalException)} }`)
+            return components.join(': ')
+        }
+        if (error instanceof Error) {
+            return `${error.name}: ${error.message}`
+        }
+        return `${error}`
+    }
+}

--- a/src/PowerAuthTokenStore.ts
+++ b/src/PowerAuthTokenStore.ts
@@ -37,7 +37,7 @@ export class PowerAuthTokenStore {
      * @return true if token exists in local database.
      */
     hasLocalToken(tokenName: string): Promise<boolean> {
-        return this.wrapper.call("hasLocalToken", tokenName);
+        return this.wrapper.callBool("hasLocalToken", tokenName);
     }
 
     /**

--- a/src/PowerAuthTokenStore.ts
+++ b/src/PowerAuthTokenStore.ts
@@ -34,7 +34,7 @@ export class PowerAuthTokenStore {
      * Quick check whether the token with name is in local database.
      *
      * @param tokenName Name of access token to be checked.
-     * @return true if token exists in local database.
+     * @returns true if token exists in local database.
      */
     hasLocalToken(tokenName: string): Promise<boolean> {
         return NativeWrapper.thisCallBool("hasLocalToken", this.instanceId, tokenName);
@@ -44,7 +44,7 @@ export class PowerAuthTokenStore {
      * Returns token if the token is already in local database
      * 
      * @param tokenName Name of access token to be returned
-     * @return token object if in the local database (or throws)
+     * @returns token object if in the local database (or throws)
      */
      getLocalToken(tokenName: string): Promise<PowerAuthToken> {
         return NativeWrapper.thisCall("getLocalToken", this.instanceId, tokenName);
@@ -76,7 +76,7 @@ export class PowerAuthTokenStore {
      *
      * @param tokenName Name of requested token.
      * @param authentication An authentication instance specifying what factors should be used for token creation.
-     * @return PowerAuth token with already generated header
+     * @returns PowerAuth token with already generated header
      */
     async requestAccessToken(tokenName: string, authentication: PowerAuthAuthentication): Promise<PowerAuthToken> {
         return NativeWrapper.thisCall("requestAccessToken", this.instanceId, tokenName, await this.authResolver.resolve(authentication));

--- a/src/PowerAuthTokenStore.ts
+++ b/src/PowerAuthTokenStore.ts
@@ -16,7 +16,8 @@
 
 import { PowerAuthAuthentication } from './model/PowerAuthAuthentication';
 import { PowerAuthAuthorizationHttpHeader } from './model/PowerAuthAuthorizationHttpHeader';
-import { __NativeWrapper } from "./internal/NativeWrapper";
+import { NativeWrapper } from "./internal/NativeWrapper";
+import { AuthResolver as AuthResolver } from './internal/AuthResolver';
 
 /**
  * The PowerAuthTokenStore provides interface for managing access tokens. The class is using Keychain as 
@@ -26,8 +27,7 @@ import { __NativeWrapper } from "./internal/NativeWrapper";
  */
 export class PowerAuthTokenStore {
 
-    constructor(instanceId: string) {
-        this.wrapper = new __NativeWrapper(instanceId);
+    constructor(private instanceId: string, private authResolver: AuthResolver) {
     }
 
     /**
@@ -37,7 +37,7 @@ export class PowerAuthTokenStore {
      * @return true if token exists in local database.
      */
     hasLocalToken(tokenName: string): Promise<boolean> {
-        return this.wrapper.callBool("hasLocalToken", tokenName);
+        return NativeWrapper.thisCallBool("hasLocalToken", this.instanceId, tokenName);
     }
 
     /**
@@ -47,7 +47,7 @@ export class PowerAuthTokenStore {
      * @return token object if in the local database (or throws)
      */
      getLocalToken(tokenName: string): Promise<PowerAuthToken> {
-        return this.wrapper.call("getLocalToken", tokenName);
+        return NativeWrapper.thisCall("getLocalToken", this.instanceId, tokenName);
     }
 
     /**
@@ -56,14 +56,14 @@ export class PowerAuthTokenStore {
      * @param tokenName token to be removed
      */
     removeLocalToken(tokenName: string): Promise<void> {
-        return this.wrapper.call("removeLocalToken", tokenName);
+        return NativeWrapper.thisCall("removeLocalToken", this.instanceId, tokenName);
     }
 
     /**
      * Remove all tokens from local database. This method doesn't issue a HTTP request to the server.
      */
     removeAllLocalTokens(): Promise<void> {
-        return this.wrapper.call("removeAllLocalTokens");
+        return NativeWrapper.thisCall("removeAllLocalTokens", this.instanceId);
     }
 
     /**
@@ -79,7 +79,7 @@ export class PowerAuthTokenStore {
      * @return PowerAuth token with already generated header
      */
     async requestAccessToken(tokenName: string, authentication: PowerAuthAuthentication): Promise<PowerAuthToken> {
-        return this.wrapper.call("requestAccessToken", tokenName, await this.wrapper.authenticate(authentication));
+        return NativeWrapper.thisCall("requestAccessToken", this.instanceId, tokenName, await this.authResolver.resolve(authentication));
     }
 
     /**
@@ -93,7 +93,7 @@ export class PowerAuthTokenStore {
      * @param tokenName Name of token to be removed
      */
     removeAccessToken(tokenName: string): Promise<void> {
-        return this.wrapper.call("removeAccessToken", tokenName);
+        return NativeWrapper.thisCall("removeAccessToken", this.instanceId, tokenName);
     }
 
     /**
@@ -103,10 +103,8 @@ export class PowerAuthTokenStore {
      * @returns header or throws
      */
     generateHeaderForToken(tokenName: string): Promise<PowerAuthAuthorizationHttpHeader> {
-        return this.wrapper.call("generateHeaderForToken", tokenName ?? "");
+        return NativeWrapper.thisCall("generateHeaderForToken", this.instanceId, tokenName ?? "");
     }
-
-    private wrapper: __NativeWrapper;
 }
 
 export interface PowerAuthToken {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@
 export * from './PowerAuth';
 export * from './PowerAuthActivationCodeUtil';
 export * from './PowerAuthTokenStore';
+export * from './PowerAuthDebug';
 
 // Model objects
 

--- a/src/internal/AuthResolver.ts
+++ b/src/internal/AuthResolver.ts
@@ -1,0 +1,63 @@
+//
+// Copyright 2022 Wultra s.r.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { Platform } from 'react-native';
+import { PowerAuthAuthentication } from '../index';
+import { NativeWrapper } from './NativeWrapper';
+
+/**
+ * The `AuthResolver` helper class hides internal dependencies when PowerAuthAuthentication needs to be
+ * resolved in case of biometry factor is used.
+ */
+export class AuthResolver {
+    /**
+     * Construct resolver with required instance identifier.
+     * @param instanceId PowerAuth instnace identifier.
+     */
+    constructor(private instanceId: string) {
+    }
+
+    /**
+     * Method will process `PowerAuthAuthentication` object are will return object according to the platform.
+     * 
+     * @param authentication authentication configuration
+     * @param makeReusable if the object should be forced to be reusable
+     * @returns configured authorization object
+     */
+    async resolve(authentication: PowerAuthAuthentication, makeReusable: boolean = false): Promise<PowerAuthAuthentication> {
+        const obj: ReusablePowerAuthAuthentication = { ...authentication };
+        // On android, we need to fetch the key for every biometric authentication.
+        // If the key is already set, use it (we're processing reusable biometric authentication)
+        if ((Platform.OS == 'android' && authentication.useBiometry && (obj.biometryKey === undefined || makeReusable)) || (Platform.OS == 'ios' && makeReusable)) {
+            try {
+                obj.biometryKey = (await NativeWrapper.thisCall("authenticateWithBiometry", this.instanceId, authentication.biometryTitle ?? "??", authentication.biometryMessage ?? "??")) as string;
+                return obj;
+            } catch (e) {
+                throw NativeWrapper.processException(e)
+            }
+        }
+        
+        // no need for processing, just return original object
+        return authentication;
+    }
+}
+
+/**
+ * Extended PowerAuthAuthentication object containing a biometry key.
+ */
+class ReusablePowerAuthAuthentication extends PowerAuthAuthentication {
+    biometryKey?: string
+}

--- a/src/internal/NativeWrapper.ts
+++ b/src/internal/NativeWrapper.ts
@@ -19,13 +19,11 @@ import { PowerAuthError } from '../model/PowerAuthError';
 import { PowerAuthDebug } from '../PowerAuthDebug';
 
 interface StaticCallTrampoline {
-    call<T>(name: string, args: any[]): Promise<T>;
-    callBool(name: string, args: any[]): Promise<boolean>;
+    call<T>(name: string, args: any[]): Promise<T>
 }
 
 interface ThisCallTrampoline {
-    call<T>(name: string, instanceId: string, args: any[]): Promise<T>;
-    callBool(name: string, instanceId: string, args: any[]): Promise<boolean>
+    call<T>(name: string, instanceId: string, args: any[]): Promise<T>
 }
 
 /**
@@ -39,13 +37,6 @@ class DefaultStaticCall implements StaticCallTrampoline {
             throw NativeWrapper.processException(e);
         }
     }
-    async callBool(name: string, args: any[]): Promise<boolean> {
-        try {
-            return await patchBool(((NativeModules.PowerAuth[name] as Function).apply(null, args)));
-        } catch (e) {
-            throw NativeWrapper.processException(e);
-        }
-    }
 }
 
 /**
@@ -55,13 +46,6 @@ class DefaultThisCall implements ThisCallTrampoline {
     async call<T>(name: string, instanceId: string, args: any[]): Promise<T> {
         try {
             return await ((NativeModules.PowerAuth[name] as Function).apply(null, [instanceId, ...args]));
-        } catch (e) {
-            throw NativeWrapper.processException(e);
-        }
-    }
-    async callBool(name: string, instanceId: string, args: any[]): Promise<boolean> {
-        try {
-            return await patchBool((NativeModules.PowerAuth[name] as Function).apply(null, [instanceId, ...args]));
         } catch (e) {
             throw NativeWrapper.processException(e);
         }
@@ -80,25 +64,6 @@ class DebugStaticCall implements StaticCallTrampoline {
                 console.log(`call ${msg}`)
             }
             const r = await ((NativeModules.PowerAuth[name] as Function).apply(null, args))
-            if (this.traceCall) {
-                console.log(` ret ${msg} => ${JSON.stringify(r)}`)
-            }
-            return r
-        } catch (e) {
-            const te = NativeWrapper.processException(e)
-            if (this.traceFail) {
-                console.error(`fail ${msg} => ${PowerAuthDebug.describeError(te)}`)
-            }
-            throw te
-        }
-    }
-    async callBool(name: string, args: any[]): Promise<boolean> {
-        const msg = this.traceCall || this.traceFail ? `PowerAuth.${name}(${prettyArgs(args)})` : undefined
-        try {
-            if (this.traceCall) {
-                console.log(`call ${msg}`)
-            }
-            const r = await patchBool(((NativeModules.PowerAuth[name] as Function).apply(null, args)))
             if (this.traceCall) {
                 console.log(` ret ${msg} => ${JSON.stringify(r)}`)
             }
@@ -137,25 +102,6 @@ class DebugThisCall implements ThisCallTrampoline {
             throw te
         }
     }
-    async callBool(name: string, instanceId: string, args: any[]): Promise<boolean> {
-        const msg = this.traceCall || this.traceFail ? `PowerAuth.${name}(${prettyArgs([instanceId, ...args])})` : undefined
-        try {
-            if (this.traceCall) {
-                console.log(`call ${msg}`)
-            }
-            const r = await patchBool((NativeModules.PowerAuth[name] as Function).apply(null, [instanceId, ...args]))
-            if (this.traceCall) {
-                console.log(` ret ${msg} => ${JSON.stringify(r)}`)
-            }
-            return r
-        } catch (e) {
-            const te = NativeWrapper.processException(e)
-            if (this.traceFail) {
-                console.error(`fail ${msg} => ${PowerAuthDebug.describeError(te)}`)
-            }
-            throw te
-        }
-    }
 }
 
 /**
@@ -173,8 +119,19 @@ export class NativeWrapper {
      * @param args Additional arguments for the function.
      * @returns Promise with return type.
      */
-    static async thisCall<T>(name: string, instanceId: string, ...args): Promise<T> {
+    static thisCall<T>(name: string, instanceId: string, ...args): Promise<T> {
         return this.thisTrampoline.call(name, instanceId, [ ...args ])
+    }
+
+    /**
+     * Perform call to the native function with given name.
+     * @param name Name of function to call.
+     * @param instanceId PowerAuth instance identifier.
+     * @param args Additional arguments for the function.
+     * @returns Promise with optional return type.
+     */
+    static thisCallNull<T>(name: string, instanceId: string, ...args): Promise<T | undefined> {
+        return patchNull(this.thisTrampoline.call(name, instanceId, [ ...args ]))
     }
 
     /**
@@ -184,23 +141,41 @@ export class NativeWrapper {
      * @param args Additional arguments for the function.
      * @returns Promise with boolean type.
      */
-    static async thisCallBool(name: string, instanceId: string, ...args): Promise<boolean> {
-        return this.thisTrampoline.callBool(name, instanceId, [ ...args ])
+    static thisCallBool(name: string, instanceId: string, ...args): Promise<boolean> {
+        return patchBool(this.thisTrampoline.call(name, instanceId, [ ...args ]))
     }
 
     /**
      * Perform call to the native function with given name. The method is useful in case that
-     * call to functions that doesn't require instance identifier is required.
+     * call to functions doesn't require instance identifier.
      * @param name Name of function to call.
      * @param args Additional arguments for the function.
-     * @returns 
+     * @returns Promise with type.
      */
-    static async staticCall<T>(name: string, ...args): Promise<T> {
+    static staticCall<T>(name: string, ...args): Promise<T> {
         return this.staticTrampoline.call(name, [ ...args ])
     }
+    
+    /**
+     * Perform call to the native function with given name. The method is useful in case that
+     * call to functions doesn't require instance identifier.
+     * @param name Name of function to call.
+     * @param args Additional arguments for the function.
+     * @returns Promise with optiomal return type.
+     */
+    static staticCallNull<T>(name: string, ...args): Promise<T | undefined> {
+        return patchNull(this.staticTrampoline.call(name, [ ...args ]))
+    }
 
-    static async staticCallBool(name: string, ...args): Promise<boolean> {
-        return this.staticTrampoline.callBool(name, [ ...args ])
+    /**
+     * Perform call to the native function with given name. The method is useful in case that
+     * call to functions doesn't require instance identifier.
+     * @param name Name of function to call.
+     * @param args Additional arguments for the function.
+     * @returns Promise with bool type.
+     */
+    static staticCallBool(name: string, ...args): Promise<boolean> {
+        return patchBool(this.staticTrampoline.call(name, [ ...args ]))
     }
 
     /**
@@ -229,15 +204,15 @@ export class NativeWrapper {
      * @param message Optional message.
      * @returns Instance of PowerAuthError.
      */
-    static processException(exception: any, message: string | null = null): PowerAuthError {
+    static processException(exception: any, message: string | undefined = undefined): PowerAuthError {
         // Initial checks:
-        // - Check if exception is null. That can happen when non-native exception is processed.
+        // - Check if exception is undefined. That can happen when non-native exception is processed.
         // - Check if the exception is already PowerAuthError type. If so, then return the same instance.
-        if (exception == null) {
-            return new PowerAuthError(null, message ?? "Operation failed with unspecified error")
+        if (!exception) {
+            return new PowerAuthError(undefined, message ?? "Operation failed with unspecified error")
         } else if (exception instanceof PowerAuthError) {
             // There's no additional message, we can return exception as it is.
-            if (message == null) {
+            if (!message) {
                 return exception
             }
             // There's additional message, so wrap PowerAuthError into another PowerAuthError
@@ -249,7 +224,7 @@ export class NativeWrapper {
         } else if (Platform.OS == "ios") {
             return this.processIosException(exception, message)
         } else {
-            return new PowerAuthError(null, "Unsupported platform")
+            return new PowerAuthError(undefined, "Unsupported platform")
         }
     }
 
@@ -260,7 +235,7 @@ export class NativeWrapper {
      * @param message Optional message.
      * @returns Instance of PowerAuthError.
      */
-    private static processIosException(exception: any, message: string | null = null): PowerAuthError {
+    private static processIosException(exception: any, message: string | undefined = undefined): PowerAuthError {
         return new PowerAuthError(exception, message)
     }
 
@@ -271,7 +246,7 @@ export class NativeWrapper {
      * @param message Optional message.
      * @returns Instance of PowerAuthError.
      */
-    private static processAndroidException(exception: any, message: string | null = null): PowerAuthError {
+    private static processAndroidException(exception: any, message: string | undefined = undefined): PowerAuthError {
         return new PowerAuthError(exception, message)
     }
 }
@@ -292,6 +267,21 @@ function patchBool(originalPromise: Promise<boolean>): Promise<boolean> {
             .catch(f => rejected(f))
     })
 }
+
+/**
+ * Function patch nullable value (e.g. null or undefined) returned from native code to be always undefined.
+ * The reason for this is that on iOS, we marshal BOOL as NSNumber.
+ * @param originalPromise Original promise which result needs to be patched.
+ * @returns Patched promise that always resolve to value or undefined.
+ */
+ function patchNull<T>(originalPromise: Promise<T | undefined>): Promise<T | undefined> {
+    return new Promise((resolved, rejected) => {
+        originalPromise
+            .then(r => resolved(r ?? undefined))
+            .catch(f => rejected(f))
+    })
+}
+
 /**
  * Function translate array of arguments into pretty string.
  * @param args Array with arguments.

--- a/src/model/PowerAuthActivation.ts
+++ b/src/model/PowerAuthActivation.ts
@@ -22,20 +22,20 @@
 
     /** parameters that are filled by create* methods  */ 
 
-    activationName: string;
-    activationCode?: string | null = null;
-    recoveryCode?: string | null = null;
-    recoveryPuk?: string | null = null;
-    identityAttributes?: any = null;
+    activationName: string
+    activationCode?: string
+    recoveryCode?: string
+    recoveryPuk?: string
+    identityAttributes: any
     
     /** Extra attributes of the activation, used for application specific purposes (for example, info about the clientdevice or system). This extras string will be associated with the activation record on PowerAuth Server. */
-    extras?: string | null = null;
+    extras?: string
 
     /** Custom attributes object that are processed on Intermediate Server Application. Note that this custom data will not be associated with the activation record on PowerAuth Server */
-    customAttributes?: any = null;
+    customAttributes: any
 
     /** Additional activation OTP that can be used only with a regular activation, by activation code */
-    additionalActivationOtp?: string | null = null;
+    additionalActivationOtp?: string
 
     /**
      * Private constructor, used internally.
@@ -54,7 +54,7 @@
      * 
      * @param activationCode Activation code, obtained either via QR code scanning or by manual entry.
      * @param name Activation name to be used for the activation.
-     * @return New instance of `PowerAuthActivation`.
+     * @returns New instance of `PowerAuthActivation`.
      */
     static createWithActivationCode(activationCode: string, name: string): PowerAuthActivation {
         const a = new PowerAuthActivation(name);
@@ -72,7 +72,7 @@
      * @param recoveryCode Recovery code, obtained either via QR code scanning or by manual entry.
      * @param recoveryPuk PUK obtained by manual entry.
      * @param name Activation name to be used for the activation.
-     * @return New instance of `PowerAuthActivation`.
+     * @returns New instance of `PowerAuthActivation`.
      */
     static createWithRecoveryCode(recoveryCode: string, recoveryPuk: string, name: string): PowerAuthActivation {
         const a = new PowerAuthActivation(name);
@@ -90,7 +90,7 @@
      * 
      * @param identityAttributes Custom activation parameters that are used to prove identity of a user (each object value is serialized and used).
      * @param name Activation name to be used for the activation.
-     * @return New instance of `PowerAuthActivation`.
+     * @returns New instance of `PowerAuthActivation`.
      */
     static createWithIdentityAttributes(identityAttributes: any, name: string): PowerAuthActivation {
         const a = new PowerAuthActivation(name);

--- a/src/model/PowerAuthActivationState.ts
+++ b/src/model/PowerAuthActivationState.ts
@@ -14,11 +14,35 @@
  * limitations under the License.
  */
 
+/**
+ * The `PowerAuthActivationState` enum defines all possible states of activation.
+ * The state is a part of information received together with the rest
+ * of the `PowerAuthActivationStatus` object.
+ */
 export enum PowerAuthActivationState {
+    /**
+     * The activation is just created.
+     */
     CREATED = "CREATED",
+    /**
+     * The activation is not completed yet on the server.
+     */
     PENDING_COMMIT = "PENDING_COMMIT",
+    /**
+     * The shared secure context is valid and active.
+     */
     ACTIVE = "ACTIVE",
+    /**
+     * The activation is blocked.
+     */
     BLOCKED = "BLOCKED",
+    /**
+     * The activation doesn't exist anymore.
+     */
     REMOVED = "REMOVED",
+    /**
+     * The activation is technically blocked. You cannot use it anymore
+     * for the signature calculations.
+     */
     DEADLOCK = "DEADLOCK"
 }

--- a/src/model/PowerAuthActivationStatus.ts
+++ b/src/model/PowerAuthActivationStatus.ts
@@ -16,9 +16,24 @@
 
 import { PowerAuthActivationState } from './PowerAuthActivationState';
 
+/**
+ * The `PowerAuthActivationStatus` object represents complete status of the activation.
+ */
 export interface PowerAuthActivationStatus {
-    state: PowerAuthActivationState;
-    failCount: number;
-    maxFailCount: number;
-    remainingAttempts: number;
+    /**
+     * State of the activation.
+     */
+    state: PowerAuthActivationState
+    /**
+     * Number of failed authentication attempts in a row.
+     */
+    failCount: number
+    /**
+     * Maximum number of allowed failed authentication attempts in a row.
+     */
+    maxFailCount: number
+    /**
+     * Contains `(maxFailCount - failCount)` if state is `ACTIVE`, otherwise 0.
+     */
+    remainingAttempts: number
 }

--- a/src/model/PowerAuthAuthentication.ts
+++ b/src/model/PowerAuthAuthentication.ts
@@ -19,16 +19,16 @@
  */
 export class PowerAuthAuthentication {
     /** Indicates if a possession factor should be used. */
-    usePossession: boolean = false;
+    usePossession: boolean = false
     /** Indicates if a biometry factor should be used. */
-    useBiometry: boolean = false;
+    useBiometry: boolean = false
     /** Password to be used for knowledge factor, or nil of knowledge factor should not be used */
-    userPassword?: string | null = null;
+    userPassword?: string
     /**
      * Message displayed when prompted for biometric authentication
      */
-    biometryMessage: string | null = null;
+    biometryMessage?: string
 
     /** (Android only) Title of biometric prompt */
-    biometryTitle: string | null = null;
+    biometryTitle?: string
 };

--- a/src/model/PowerAuthAuthorizationHttpHeader.ts
+++ b/src/model/PowerAuthAuthorizationHttpHeader.ts
@@ -15,7 +15,7 @@
  */
 
 /**
- * Class representing authorization HTTP header with the PowerAuth-Authorization or PowerAuth-Token signature.
+ * Object representing authorization HTTP header with the PowerAuth-Authorization or PowerAuth-Token signature.
  */
  export interface PowerAuthAuthorizationHttpHeader {
     /**
@@ -23,7 +23,9 @@
      * contains value "X-PowerAuth-Authorization" for standard authorization and "X-PowerAuth-Token" for
      * token-based authorization.
      */
-    key: string;
-    /** Computed value of the PowerAuth HTTP Authorization Header, to be used in HTTP requests "as is". */
-    value: string;
+    key: string
+    /** 
+     * Computed value of the PowerAuth HTTP Authorization Header, to be used in HTTP requests "as is". 
+     */
+    value: string
 }

--- a/src/model/PowerAuthBiometryInfo.ts
+++ b/src/model/PowerAuthBiometryInfo.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+/**
+ * Object contains complex information about type and state of biometry on the device.
+ */
 export interface PowerAuthBiometryInfo {
     /** 
      * Evaluate whether the biometric authentication is supported on the system. 
@@ -21,16 +24,16 @@ export interface PowerAuthBiometryInfo {
      * Note that the property contains "false" on iOS if biometry is not enrolled or if it has been locked down. 
      * To distinguish between an availability and lockdown you can use `biometryType` and `canAuthenticate`.
      */
-    isAvailable: boolean;
+    isAvailable: boolean
     /** 
      * Return type of biometry supported on the system. 
      */
-    biometryType: PowerAuthBiometryType;
+    biometryType: PowerAuthBiometryType
     /** 
      * Check whether biometric authentication is available on this authenticator and biometric data
      * are enrolled on the system. 
      */
-    canAuthenticate: PowerAuthBiometryStatus;
+    canAuthenticate: PowerAuthBiometryStatus
 }
 
 /**

--- a/src/model/PowerAuthConfirmRecoveryCodeDataResult.ts
+++ b/src/model/PowerAuthConfirmRecoveryCodeDataResult.ts
@@ -21,5 +21,5 @@ export interface PowerAuthConfirmRecoveryCodeDataResult {
     /** 
      * Indicates that the code was already confirmed in the past 
      */
-    alreadyConfirmed: boolean;
+    alreadyConfirmed: boolean
 }

--- a/src/model/PowerAuthCreateActivationResult.ts
+++ b/src/model/PowerAuthCreateActivationResult.ts
@@ -20,7 +20,19 @@ import {PowerAuthRecoveryActivationData} from "./PowerAuthRecoveryActivationData
  * Success object returned by "createActivation" call.
  */
  export interface PowerAuthCreateActivationResult {
-    activationFingerprint: string;
-    activationRecovery?: PowerAuthRecoveryActivationData;
-    customAttributes?: any; // when available, contents of this object depends of your enrollment server configuration
+    /**
+     * Decimalized fingerprint calculated from device's and server's public keys.
+     */
+    activationFingerprint: string
+    /**
+     * If supported and enabled on the server, then the object contains "Recovery Code" and PUK,
+     * created for this particular activation. Your application should display that values to the user
+     * and forget the values immediately. You should NEVER store values from the object persistently
+     * on the device.
+     */
+    activationRecovery?: PowerAuthRecoveryActivationData
+    /**
+     * When available, contents of this object depends of your enrollment server configuration.
+     */
+    customAttributes?: any
 }

--- a/src/model/PowerAuthError.ts
+++ b/src/model/PowerAuthError.ts
@@ -14,30 +14,32 @@
  * limitations under the License.
  */
 
+import { PowerAuthDebug } from "../PowerAuthDebug";
+
 /**
  * PowerAuthError is a wrapper error that is thrown by every API in this module.
  */
 export class PowerAuthError {
 
-    /** Original exception thrown by the native layer (iOS or Android). If null, then error was created in TypeScript. */
-    originalException: any;
+    /** Original exception thrown by the native layer (iOS or Android). If undefined, then error was created in TypeScript. */
+    originalException: any
 
     /** Code of the error. */
-    code?: PowerAuthErrorCode;
+    code?: PowerAuthErrorCode
     /** Message of the error. */
-    message?: string;
+    message?: string
     /** Additional error data. */
-    errorData?: any;
+    errorData?: any
 
-    constructor(exception: any, message: string | null = null, code: PowerAuthErrorCode | null = null, errorData: any = null) {
-        this.originalException = exception;
-        this.code = code ?? exception?.code ?? null;
-        this.message = message ?? exception?.message ?? null;
-        this.errorData = errorData ?? exception?.userInfo ?? null;
+    constructor(exception: any, message: string | undefined = undefined, code: PowerAuthErrorCode | undefined = undefined, errorData: any = undefined) {
+        this.originalException = exception ?? undefined
+        this.code = code ?? exception?.code ?? undefined
+        this.message = message ?? exception?.message ?? undefined
+        this.errorData = errorData ?? exception?.userInfo ?? undefined
     }
 
     print(): string {
-        return `code: ${this.code}\nmessage: ${this.message}`;
+        return PowerAuthDebug.describeError(this)
     }
 };
 

--- a/src/model/PowerAuthKeychainConfiguration.ts
+++ b/src/model/PowerAuthKeychainConfiguration.ts
@@ -64,7 +64,7 @@ export class PowerAuthKeychainConfiguration {
      * 
      * Access group name used by the `PowerAuth` keychain instances.
      */
-    accessGroupName?: string | null = null
+    accessGroupName?: string
     /**
      * ### iOS specific
      * 
@@ -75,7 +75,7 @@ export class PowerAuthKeychainConfiguration {
      * with no suite name specified, the developer is responsible for migrating data
      * to the new `UserDefaults` before using the SDK with the new suite name.
      */
-    userDefaultsSuiteName?: string | null = null
+    userDefaultsSuiteName?: string
     /**
      * ### Android specific
      * 

--- a/src/model/PowerAuthRecoveryActivationData.ts
+++ b/src/model/PowerAuthRecoveryActivationData.ts
@@ -14,7 +14,17 @@
  * limitations under the License.
  */
 
+/**
+ * The `PowerAuthRecoveryActivationData` object contains information about recovery code and PUK, created
+ * during the activation process.
+ */
 export interface PowerAuthRecoveryActivationData {
-    recoveryCode: string;
-    puk: string;
+    /**
+     * Contains recovery code.
+     */
+    recoveryCode: string
+    /**
+     * Contains PUK, valid with recovery code.
+     */
+    puk: string
 }

--- a/testapp/_tests/PowerAuthActivationCodeUtil.test.ts
+++ b/testapp/_tests/PowerAuthActivationCodeUtil.test.ts
@@ -80,7 +80,7 @@ export class PowerAuthActivationCodeUtilTests extends TestSuite {
     async testActivationCodeParser() {
         let code = await PowerAuthActivationCodeUtil.parseActivationCode('BBBBB-BBBBB-BBBBB-BTA6Q')
         expect(code.activationCode).toBe('BBBBB-BBBBB-BBBBB-BTA6Q')
-        expect(code.activationSignature).toBeNull()
+        expect(code.activationSignature).toBeUndefined()
 
         code = await PowerAuthActivationCodeUtil.parseActivationCode('CCCCC-CCCCC-CCCCC-CNUUQ#ABCD')
         expect(code.activationCode).toBe('CCCCC-CCCCC-CCCCC-CNUUQ')
@@ -186,12 +186,12 @@ export class PowerAuthActivationCodeUtilTests extends TestSuite {
         let code = await PowerAuthActivationCodeUtil.parseRecoveryCode('BBBBB-BBBBB-BBBBB-BTA6Q')
         expect(code).toBeDefined()
         expect(code.activationCode).toBe('BBBBB-BBBBB-BBBBB-BTA6Q')
-        expect(code.activationSignature).toBeNull()
+        expect(code.activationSignature).toBeUndefined()
 
         code = await PowerAuthActivationCodeUtil.parseRecoveryCode('R:BBBBB-BBBBB-BBBBB-BTA6Q')
         expect(code).toBeDefined()
         expect(code.activationCode).toBe('BBBBB-BBBBB-BBBBB-BTA6Q')
-        expect(code.activationSignature).toBeNull()
+        expect(code.activationSignature).toBeUndefined()
 
         const invalidCodes = [
             "",

--- a/testapp/_tests/PowerAuth_Activation.test.ts
+++ b/testapp/_tests/PowerAuth_Activation.test.ts
@@ -23,7 +23,6 @@ export class PowerAuth_ActivationTests extends TestWithActivation {
     async beforeAll(): Promise<void> {
         await super.beforeAll()
         this.printDebugMessages = false
-        //this.reportSkip('Temporary')
     }
 
     shouldCreateActivationBeforeTest(): boolean {
@@ -39,8 +38,8 @@ export class PowerAuth_ActivationTests extends TestWithActivation {
         expect(await sdk.canStartActivation()).toBe(true)
         expect(await sdk.hasPendingActivation()).toBe(false)
         expect(await sdk.hasValidActivation()).toBe(false)
-        expect(await sdk.getActivationIdentifier()).toBeNullish()
-        expect(await sdk.getActivationFingerprint()).toBeNullish()
+        expect(await sdk.getActivationIdentifier()).toBeUndefined()
+        expect(await sdk.getActivationFingerprint()).toBeUndefined()
 
         await this.runFailingMethodsDuringActivation('BEGIN', PowerAuthErrorCode.MISSING_ACTIVATION, PowerAuthErrorCode.MISSING_ACTIVATION)
         await expect(async () => await sdk.commitActivation(this.credentials.invalidKnowledge)).toThrow({errorCode: PowerAuthErrorCode.INVALID_ACTIVATION_STATE})
@@ -56,7 +55,7 @@ export class PowerAuth_ActivationTests extends TestWithActivation {
         //       a pending state
         const activation = PowerAuthActivation.createWithActivationCode(code, 'RN')
         const result = await sdk.createActivation(activation)
-
+        expect(result).toBeDefined()
         expect(result.activationFingerprint).toBeDefined()
 
         await this.runFailingMethodsDuringActivation('AFTER_CREATE', PowerAuthErrorCode.PENDING_ACTIVATION, PowerAuthErrorCode.MISSING_ACTIVATION)
@@ -69,33 +68,33 @@ export class PowerAuth_ActivationTests extends TestWithActivation {
 
         let activationId = await sdk.getActivationIdentifier()
         let activationFingerprint = await sdk.getActivationFingerprint()
-        expect(activationId).toBeNotNullish()
-        expect(activationFingerprint).toBeNotNullish()
+        expect(activationId).toBeDefined()
+        expect(activationFingerprint).toBeDefined()
 
         let activationDetail = await this.helper.getActivationDetail()
 
-        expect(activationDetail.devicePublicKeyFingerprint).toBeNotNullish()
+        expect(activationDetail.devicePublicKeyFingerprint).toBeDefined()
+        expect(activationId).toBe(activationDetail.activationId)
         expect(result.activationFingerprint).toBe(activationFingerprint)
         expect(result.activationFingerprint).toBe(activationDetail.devicePublicKeyFingerprint)
-        expect(activationId).toBe(activationDetail.activationId)
 
         // [ 3 ] Now commit activation locally
         await sdk.commitActivation(this.credentials.knowledge)
 
         activationId = await sdk.getActivationIdentifier()
         activationFingerprint = await sdk.getActivationFingerprint()
-        expect(activationId).toBeNotNullish()
-        expect(activationFingerprint).toBeNotNullish()
+        expect(activationId).toBeDefined()
+        expect(activationFingerprint).toBeDefined()
 
         expect(await sdk.canStartActivation()).toBe(false)
         expect(await sdk.hasPendingActivation()).toBe(false)
         expect(await sdk.hasValidActivation()).toBe(true)
 
         activationDetail = await this.helper.getActivationDetail()
-        expect(activationDetail.devicePublicKeyFingerprint).toBeNotNullish()
+        expect(activationDetail.devicePublicKeyFingerprint).toBeDefined()
+        expect(activationId).toBe(activationDetail.activationId)
         expect(result.activationFingerprint).toBe(activationFingerprint)
         expect(result.activationFingerprint).toBe(activationDetail.devicePublicKeyFingerprint)
-        expect(activationId).toBe(activationDetail.activationId)
 
         // Fetch status now
 

--- a/testapp/_tests/PowerAuth_Configure.test.ts
+++ b/testapp/_tests/PowerAuth_Configure.test.ts
@@ -66,14 +66,14 @@ export class PowerAuth_ConfigureTests extends TestWithServer {
         expect(await pa1.isConfigured()).toBe(true)
         expect(await pa2.isConfigured()).toBe(true)
         // Unline instances created in helper, pa1 & pa2
-        expect(pa1.configuration).toBeNullish()
-        expect(pa2.configuration).toBeNullish()
-        expect(pa1.keychainConfiguration).toBeNullish()
-        expect(pa2.keychainConfiguration).toBeNullish()
-        expect(pa1.clientConfiguration).toBeNullish()
-        expect(pa2.clientConfiguration).toBeNullish()
-        expect(pa1.biometryConfiguration).toBeNullish()
-        expect(pa2.biometryConfiguration).toBeNullish()
+        expect(pa1.configuration).toBeUndefined()
+        expect(pa2.configuration).toBeUndefined()
+        expect(pa1.keychainConfiguration).toBeUndefined()
+        expect(pa2.keychainConfiguration).toBeUndefined()
+        expect(pa1.clientConfiguration).toBeUndefined()
+        expect(pa2.clientConfiguration).toBeUndefined()
+        expect(pa1.biometryConfiguration).toBeUndefined()
+        expect(pa2.biometryConfiguration).toBeUndefined()
     }
 
     async testReconfigureWhileActive() {


### PR DESCRIPTION
This PR fixes the following issues:

- #114 - Always return bool on iOS
- #107 - Prefer `undefined` over `null`.

On top of that it brings the following enhancements:

- #113 - `PowerAuth` object now expose its `instanceId` to the application
- #116 - Add debug features
- Added missing documentation to public objects
 
## Note about implementation

The change brings a complete new `NativeWrapper` implementation with a slightly changed API. Now the wrapper object is completely static, so each call that require `instanceId` must provide the value as a parameter. The `testapp` now fails only on cases related to ECDSA signatures (see another PR #118) so I believe the change was done correctly.