### PR TITLE
Fix #113: Add instanceId property to PowerAuth class

### DIFF
--- a/src/PowerAuth.ts
+++ b/src/PowerAuth.ts
@@ -26,7 +26,7 @@ import { PowerAuthCreateActivationResult } from './model/PowerAuthCreateActivati
 import { PowerAuthActivation } from './model/PowerAuthActivation';
 import { PowerAuthBiometryInfo } from './model/PowerAuthBiometryInfo';
 import { PowerAuthRecoveryActivationData } from './model/PowerAuthRecoveryActivationData';
-import { PowerAuthError } from './model/PowerAuthError';
+import { PowerAuthError, PowerAuthErrorCode } from './model/PowerAuthError';
 import { PowerAuthConfirmRecoveryCodeDataResult} from './model/PowerAuthConfirmRecoveryCodeDataResult';
 import { __NativeWrapper } from "./internal/NativeWrapper";
 import { PowerAuthTokenStore } from "./PowerAuthTokenStore"
@@ -35,7 +35,10 @@ import { PowerAuthTokenStore } from "./PowerAuthTokenStore"
  * Class used for the main interaction with the PowerAuth SDK components.
  */
 export class PowerAuth {
-
+    /**
+     * Instance identifier associated to this object.
+     */
+    readonly instanceId: string
     /**
      * Configuration used to configure this instance of class. Note that modifying this property has no effect, but the
      * stored object is useful for the debugging purposes.
@@ -70,6 +73,7 @@ export class PowerAuth {
      * @param instanceId Identifier of the PowerAuthSDK instance. The bundle identifier/packagename is recommended.
      */
     constructor(instanceId: string) {
+        this.instanceId = instanceId
         this.wrapper = new __NativeWrapper(instanceId);
         this.tokenStore = new PowerAuthTokenStore(instanceId);
     }
@@ -441,6 +445,9 @@ export class PowerAuth {
      * @param groupedAuthenticationCalls call that will use reusable authentication object
      */
     async groupedBiometricAuthentication(authentication: PowerAuthAuthentication, groupedAuthenticationCalls: (reusableAuthentication: PowerAuthAuthentication) => Promise<void>): Promise<void> {
+        if (!await this.isConfigured()) {
+            throw new PowerAuthError(null, "Instance is not configured", PowerAuthErrorCode.INSTANCE_NOT_CONFIGURED);
+        }
         if (authentication.useBiometry == false) {
             throw new PowerAuthError(null, "Requesting biometric authentication, but `useBiometry` is set to false.");
         }


### PR DESCRIPTION
This PR adds `instanceId` property to `PowerAuth` class. On top of that, it fixes error handling if `groupedBiometricAuthentication()` method is called on not-configured instance. This change follows general behavior of native methods.