### PR TITLE
Native object register for iOS

### DIFF
--- a/.deploy/package.json
+++ b/.deploy/package.json
@@ -17,8 +17,8 @@
     "lib/internal/*.js",
     "lib/model/*.*",
     "ios/PowerAuth.xcodeproj/project.pbxproj",
-    "ios/PowerAuth/PowerAuth.m",
-    "ios/PowerAuth/PowerAuth.h",
+    "ios/PowerAuth/*.m",
+    "ios/PowerAuth/*.h",
     "react-native-powerauth-mobile-sdk.podspec"
   ],
   "scripts": {

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -6,14 +6,25 @@ In case you encounter a problem with this library, then try to turn-on a detaile
 
 ```javascript
 // Enable debug log with failed call to native function.
-PowerAuthDebug.traceNativeCodeCalls(true)
+PowerAuthDebug.traceNativeCodeCalls(true);
 // Trace all calls to native library
-PowerAuthDebug.traceNativeCodeCalls(true, true)
+PowerAuthDebug.traceNativeCodeCalls(true, true);
 ```
 
 <!-- begin box warning -->
 The `PowerAuthDebug` class is effective only if global `__DEV__` constant is `true`. We don't want to log the sensitive information to the console in the production application.
 <!-- end -->
+
+## Dumping native objects
+
+If `__DEV__` mode is turned on, then you can dump information about all native objects allocated and used by React Native PowerAuth Mobile SDK:
+
+```javascript
+// Dump all objects
+await PowerAuthDebug.dumpNativeObjects();
+// Dump objects related to PowerAuth instance
+await PowerAuthDebug.dumpNativeObjects(powerAuth.instanceId);
+```
 
 ## Read Next
 

--- a/ios/PowerAuth.xcodeproj/project.pbxproj
+++ b/ios/PowerAuth.xcodeproj/project.pbxproj
@@ -7,6 +7,16 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BF1F659C28F587B40093A45A /* PowerAuthObjectRegister.h in Headers */ = {isa = PBXBuildFile; fileRef = BF1F659A28F587B40093A45A /* PowerAuthObjectRegister.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BF1F659D28F587B40093A45A /* PowerAuthObjectRegister.m in Sources */ = {isa = PBXBuildFile; fileRef = BF1F659B28F587B40093A45A /* PowerAuthObjectRegister.m */; };
+		BF1F65A028F6EF900093A45A /* Errors.h in Headers */ = {isa = PBXBuildFile; fileRef = BF1F659E28F6EF900093A45A /* Errors.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BF1F65A128F6EF900093A45A /* Errors.m in Sources */ = {isa = PBXBuildFile; fileRef = BF1F659F28F6EF900093A45A /* Errors.m */; };
+		BF1F65A428F80CF80093A45A /* Utilities.h in Headers */ = {isa = PBXBuildFile; fileRef = BF1F65A228F80CF80093A45A /* Utilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BF1F65A528F80CF80093A45A /* Utilities.m in Sources */ = {isa = PBXBuildFile; fileRef = BF1F65A328F80CF80093A45A /* Utilities.m */; };
+		BF1F65A828F810880093A45A /* PowerAuthData.h in Headers */ = {isa = PBXBuildFile; fileRef = BF1F65A628F810880093A45A /* PowerAuthData.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BF1F65A928F810880093A45A /* PowerAuthData.m in Sources */ = {isa = PBXBuildFile; fileRef = BF1F65A728F810880093A45A /* PowerAuthData.m */; };
+		BF1F65AB28F8464B0093A45A /* PowerAuthObjectRegister+JS.m in Sources */ = {isa = PBXBuildFile; fileRef = BF1F65AA28F8464B0093A45A /* PowerAuthObjectRegister+JS.m */; };
+		BF1F65AE28F9581F0093A45A /* Constants.h in Headers */ = {isa = PBXBuildFile; fileRef = BF1F65AC28F9581F0093A45A /* Constants.h */; };
 		CAC0BE336028DD00272CEB09 /* libPods-PowerAuth.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D3CE2470A643546DD46BA726 /* libPods-PowerAuth.a */; };
 		DCEDF08B249E59EF00918481 /* PowerAuth.h in Headers */ = {isa = PBXBuildFile; fileRef = DCEDF089249E59EF00918481 /* PowerAuth.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DCEDF092249E5A8600918481 /* PowerAuth.m in Sources */ = {isa = PBXBuildFile; fileRef = DCEDF091249E5A8600918481 /* PowerAuth.m */; };
@@ -15,6 +25,16 @@
 /* Begin PBXFileReference section */
 		04AE46321019BF22569F5B81 /* Pods-PowerAuth.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PowerAuth.debug.xcconfig"; path = "Target Support Files/Pods-PowerAuth/Pods-PowerAuth.debug.xcconfig"; sourceTree = "<group>"; };
 		2893562A68484B27897BACFB /* Pods-PowerAuth.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PowerAuth.release.xcconfig"; path = "Target Support Files/Pods-PowerAuth/Pods-PowerAuth.release.xcconfig"; sourceTree = "<group>"; };
+		BF1F659A28F587B40093A45A /* PowerAuthObjectRegister.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PowerAuthObjectRegister.h; sourceTree = "<group>"; };
+		BF1F659B28F587B40093A45A /* PowerAuthObjectRegister.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PowerAuthObjectRegister.m; sourceTree = "<group>"; };
+		BF1F659E28F6EF900093A45A /* Errors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Errors.h; sourceTree = "<group>"; };
+		BF1F659F28F6EF900093A45A /* Errors.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Errors.m; sourceTree = "<group>"; };
+		BF1F65A228F80CF80093A45A /* Utilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Utilities.h; sourceTree = "<group>"; };
+		BF1F65A328F80CF80093A45A /* Utilities.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Utilities.m; sourceTree = "<group>"; };
+		BF1F65A628F810880093A45A /* PowerAuthData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PowerAuthData.h; sourceTree = "<group>"; };
+		BF1F65A728F810880093A45A /* PowerAuthData.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PowerAuthData.m; sourceTree = "<group>"; };
+		BF1F65AA28F8464B0093A45A /* PowerAuthObjectRegister+JS.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "PowerAuthObjectRegister+JS.m"; sourceTree = "<group>"; };
+		BF1F65AC28F9581F0093A45A /* Constants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Constants.h; sourceTree = "<group>"; };
 		D3CE2470A643546DD46BA726 /* libPods-PowerAuth.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PowerAuth.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCEDF086249E59EF00918481 /* PowerAuth.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PowerAuth.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCEDF089249E59EF00918481 /* PowerAuth.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PowerAuth.h; sourceTree = "<group>"; };
@@ -72,8 +92,18 @@
 		DCEDF088249E59EF00918481 /* PowerAuth */ = {
 			isa = PBXGroup;
 			children = (
-				DCEDF091249E5A8600918481 /* PowerAuth.m */,
+				BF1F65AC28F9581F0093A45A /* Constants.h */,
+				BF1F65A228F80CF80093A45A /* Utilities.h */,
+				BF1F65A328F80CF80093A45A /* Utilities.m */,
+				BF1F659E28F6EF900093A45A /* Errors.h */,
+				BF1F659F28F6EF900093A45A /* Errors.m */,
+				BF1F659A28F587B40093A45A /* PowerAuthObjectRegister.h */,
+				BF1F659B28F587B40093A45A /* PowerAuthObjectRegister.m */,
+				BF1F65AA28F8464B0093A45A /* PowerAuthObjectRegister+JS.m */,
+				BF1F65A628F810880093A45A /* PowerAuthData.h */,
+				BF1F65A728F810880093A45A /* PowerAuthData.m */,
 				DCEDF089249E59EF00918481 /* PowerAuth.h */,
+				DCEDF091249E5A8600918481 /* PowerAuth.m */,
 				DCEDF08A249E59EF00918481 /* Info.plist */,
 			);
 			path = PowerAuth;
@@ -87,6 +117,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				DCEDF08B249E59EF00918481 /* PowerAuth.h in Headers */,
+				BF1F65A828F810880093A45A /* PowerAuthData.h in Headers */,
+				BF1F65AE28F9581F0093A45A /* Constants.h in Headers */,
+				BF1F65A428F80CF80093A45A /* Utilities.h in Headers */,
+				BF1F65A028F6EF900093A45A /* Errors.h in Headers */,
+				BF1F659C28F587B40093A45A /* PowerAuthObjectRegister.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -202,7 +237,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BF1F659D28F587B40093A45A /* PowerAuthObjectRegister.m in Sources */,
+				BF1F65A928F810880093A45A /* PowerAuthData.m in Sources */,
 				DCEDF092249E5A8600918481 /* PowerAuth.m in Sources */,
+				BF1F65A528F80CF80093A45A /* Utilities.m in Sources */,
+				BF1F65AB28F8464B0093A45A /* PowerAuthObjectRegister+JS.m in Sources */,
+				BF1F65A128F6EF900093A45A /* Errors.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/PowerAuth/Constants.h
+++ b/ios/PowerAuth/Constants.h
@@ -1,5 +1,5 @@
-/**
- * Copyright 2020 Wultra s.r.o.
+/*
+ * Copyright 2022 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-#import <React/RCTBridgeModule.h>
-#import <React/RCTInitializing.h>
-#import "PowerAuthObjectRegister.h"
+#import "Utilities.h"
 
-@interface PowerAuth: NSObject<RCTBridgeModule, RCTInitializing>
-
-@end
+/// Time interval in milliseconds to keep pre-authorized biometric
+/// key in memory.
+#define BIOMETRY_KEY_KEEP_ALIVE_TIME    10000

--- a/ios/PowerAuth/Constants.h
+++ b/ios/PowerAuth/Constants.h
@@ -19,3 +19,10 @@
 /// Time interval in milliseconds to keep pre-authorized biometric
 /// key in memory.
 #define BIOMETRY_KEY_KEEP_ALIVE_TIME    10000
+
+/// Default period in milliseconds for automatic objects cleanup job.
+#define CLEANUP_PERIOD_DEFAULT          10000
+/// Minimum allowed period for automatic objects cleanup job.
+#define CLEANUP_PERIOD_MIN                100
+/// Maximum allowed period for automatic objects cleanup job.
+#define CLEANUP_PERIOD_MAX              60000

--- a/ios/PowerAuth/Errors.h
+++ b/ios/PowerAuth/Errors.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "Utilities.h"
+
+#import <PowerAuth2/PowerAuthErrorConstants.h>
+#import <React/RCTBridgeModule.h>
+
+PA_EXTERN_C NSString * __nonnull const EC_NETWORK_ERROR;
+PA_EXTERN_C NSString * __nonnull const EC_SIGNATURE_ERROR;
+PA_EXTERN_C NSString * __nonnull const EC_INVALID_ACTIVATION_STATE;
+PA_EXTERN_C NSString * __nonnull const EC_INVALID_ACTIVATION_DATA;
+PA_EXTERN_C NSString * __nonnull const EC_MISSING_ACTIVATION;
+PA_EXTERN_C NSString * __nonnull const EC_PENDING_ACTIVATION;
+PA_EXTERN_C NSString * __nonnull const EC_BIOMETRY_CANCEL;
+PA_EXTERN_C NSString * __nonnull const EC_OPERATION_CANCELED;
+PA_EXTERN_C NSString * __nonnull const EC_INVALID_TOKEN;
+PA_EXTERN_C NSString * __nonnull const EC_ENCRYPTION_ERROR;
+PA_EXTERN_C NSString * __nonnull const EC_WRONG_PARAMETER;
+PA_EXTERN_C NSString * __nonnull const EC_PROTOCOL_UPGRADE;
+PA_EXTERN_C NSString * __nonnull const EC_PENDING_PROTOCOL_UPGRADE;
+PA_EXTERN_C NSString * __nonnull const EC_BIOMETRY_NOT_AVAILABLE;
+PA_EXTERN_C NSString * __nonnull const EC_WATCH_CONNECTIVITY;
+PA_EXTERN_C NSString * __nonnull const EC_BIOMETRY_FAILED;
+PA_EXTERN_C NSString * __nonnull const EC_AUTHENTICATION_ERROR;
+PA_EXTERN_C NSString * __nonnull const EC_RESPONSE_ERROR;
+PA_EXTERN_C NSString * __nonnull const EC_UNKNOWN_ERROR;
+PA_EXTERN_C NSString * __nonnull const EC_REACT_NATIVE_ERROR;
+PA_EXTERN_C NSString * __nonnull const EC_INVALID_ACTIVATION_OBJECT;
+PA_EXTERN_C NSString * __nonnull const EC_INVALID_ACTIVATION_CODE;
+PA_EXTERN_C NSString * __nonnull const EC_INVALID_RECOVERY_CODE;
+PA_EXTERN_C NSString * __nonnull const EC_INVALID_CHARACTER;
+PA_EXTERN_C NSString * __nonnull const EC_LOCAL_TOKEN_NOT_AVAILABLE;
+PA_EXTERN_C NSString * __nonnull const EC_CANNOT_GENERATE_TOKEN;
+PA_EXTERN_C NSString * __nonnull const EC_INSTANCE_NOT_CONFIGURED;
+PA_EXTERN_C NSString * __nonnull const EC_INVALID_NATIVE_OBJECT;
+
+/// Translates PowerAuthErrorCode into string representation.
+/// @param code Error code to convert.
+PA_EXTERN_C NSString * _Nonnull TranslatePAErrorCode(PowerAuthErrorCode code);
+
+/// Translate reported NSError into proper React Native error code and reports everything back to promise reject block.
+/// @param error Error to report.
+/// @param reject Reject promise to call.
+PA_EXTERN_C void ProcessError(NSError * _Nullable error, RCTPromiseRejectBlock _Nonnull reject);

--- a/ios/PowerAuth/Errors.m
+++ b/ios/PowerAuth/Errors.m
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2022 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "Errors.h"
+
+#import <PowerAuth2/PowerAuthRestApiErrorResponse.h>
+
+// MARK: - Error constatns
+
+NSString * const EC_NETWORK_ERROR               = @"NETWORK_ERROR";
+NSString * const EC_SIGNATURE_ERROR             = @"SIGNATURE_ERROR";
+NSString * const EC_INVALID_ACTIVATION_STATE    = @"INVALID_ACTIVATION_STATE";
+NSString * const EC_INVALID_ACTIVATION_DATA     = @"INVALID_ACTIVATION_DATA";
+NSString * const EC_MISSING_ACTIVATION          = @"MISSING_ACTIVATION";
+NSString * const EC_PENDING_ACTIVATION          = @"PENDING_ACTIVATION";
+NSString * const EC_BIOMETRY_CANCEL             = @"BIOMETRY_CANCEL";
+NSString * const EC_OPERATION_CANCELED          = @"OPERATION_CANCELED";
+NSString * const EC_INVALID_TOKEN               = @"INVALID_TOKEN";
+NSString * const EC_ENCRYPTION_ERROR            = @"ENCRYPTION_ERROR";
+NSString * const EC_WRONG_PARAMETER             = @"WRONG_PARAMETER";
+NSString * const EC_PROTOCOL_UPGRADE            = @"PROTOCOL_UPGRADE";
+NSString * const EC_PENDING_PROTOCOL_UPGRADE    = @"PENDING_PROTOCOL_UPGRADE";
+NSString * const EC_BIOMETRY_NOT_AVAILABLE      = @"BIOMETRY_NOT_AVAILABLE";
+NSString * const EC_WATCH_CONNECTIVITY          = @"WATCH_CONNECTIVITY";
+NSString * const EC_BIOMETRY_FAILED             = @"BIOMETRY_FAILED";
+NSString * const EC_AUTHENTICATION_ERROR        = @"AUTHENTICATION_ERROR";
+NSString * const EC_RESPONSE_ERROR              = @"RESPONSE_ERROR";
+NSString * const EC_UNKNOWN_ERROR               = @"UNKNOWN_ERROR";
+NSString * const EC_REACT_NATIVE_ERROR          = @"REACT_NATIVE_ERROR";
+NSString * const EC_INVALID_ACTIVATION_OBJECT   = @"INVALID_ACTIVATION_OBJECT";
+NSString * const EC_INVALID_ACTIVATION_CODE     = @"INVALID_ACTIVATION_CODE";
+NSString * const EC_INVALID_RECOVERY_CODE       = @"INVALID_RECOVERY_CODE";
+NSString * const EC_INVALID_CHARACTER           = @"INVALID_CHARACTER";
+NSString * const EC_LOCAL_TOKEN_NOT_AVAILABLE   = @"LOCAL_TOKEN_NOT_AVAILABLE";
+NSString * const EC_CANNOT_GENERATE_TOKEN       = @"CANNOT_GENERATE_TOKEN";
+NSString * const EC_INSTANCE_NOT_CONFIGURED     = @"INSTANCE_NOT_CONFIGURED";
+NSString * const EC_INVALID_NATIVE_OBJECT       = @"INVALID_NATIVE_OBJECT";
+
+// MARK: - Utility functions
+
+/// Translates PowerAuthErrorCode into string representation.
+/// @param code Error code to convert.
+NSString * TranslatePAErrorCode(PowerAuthErrorCode code)
+{
+    switch (code) {
+        case PowerAuthErrorCode_NetworkError: return EC_NETWORK_ERROR;
+        case PowerAuthErrorCode_SignatureError: return EC_SIGNATURE_ERROR;
+        case PowerAuthErrorCode_InvalidActivationState: return EC_INVALID_ACTIVATION_STATE;
+        case PowerAuthErrorCode_InvalidActivationData: return EC_INVALID_ACTIVATION_DATA;
+        case PowerAuthErrorCode_MissingActivation: return EC_MISSING_ACTIVATION;
+        case PowerAuthErrorCode_ActivationPending: return EC_PENDING_ACTIVATION;
+        case PowerAuthErrorCode_BiometryCancel: return EC_BIOMETRY_CANCEL;
+        case PowerAuthErrorCode_OperationCancelled: return EC_OPERATION_CANCELED;
+        case PowerAuthErrorCode_InvalidActivationCode: return EC_INVALID_ACTIVATION_CODE;
+        case PowerAuthErrorCode_InvalidToken: return EC_INVALID_TOKEN;
+        case PowerAuthErrorCode_Encryption: return EC_ENCRYPTION_ERROR;
+        case PowerAuthErrorCode_WrongParameter: return EC_WRONG_PARAMETER;
+        case PowerAuthErrorCode_ProtocolUpgrade: return EC_PROTOCOL_UPGRADE;
+        case PowerAuthErrorCode_PendingProtocolUpgrade: return EC_PENDING_PROTOCOL_UPGRADE;
+        case PowerAuthErrorCode_BiometryNotAvailable: return EC_BIOMETRY_NOT_AVAILABLE;
+        case PowerAuthErrorCode_WatchConnectivity: return EC_WATCH_CONNECTIVITY;
+        case PowerAuthErrorCode_BiometryFailed: return EC_BIOMETRY_FAILED;
+        default: return [[NSString alloc] initWithFormat:@"UNKNOWN_%li", code];
+    }
+}
+
+/// Method translate reported NSError into proper React Native error code and reports everything back promise reject block.
+/// @param error Error to report.
+/// @param reject Reject promise to call.
+void ProcessError(NSError * error, RCTPromiseRejectBlock reject)
+{
+    NSString * errorCode = nil;
+    NSString * message;
+    if (error != nil) {
+        // Keep message
+        message = error.localizedDescription;
+        // If powerAuthErrorCode is different than .NA, then it's PowerAuthDomain error.
+        PowerAuthErrorCode paErrorCode = error.powerAuthErrorCode;
+        if (paErrorCode != PowerAuthErrorCode_NA) {
+            // Handle PA error
+            NSDictionary * responseData = CAST_TO(error.userInfo[PowerAuthErrorInfoKey_AdditionalInfo], NSDictionary);
+            if (responseData != nil) {
+                // Handle error response received from the server. In this case, we have to re-create a new NSError, because
+                // React Native layer cannot translate our custom objects, stored in NSError. So, we have to create a new userInfo with
+                // a plain serializable data.
+                PowerAuthRestApiErrorResponse * responseObject = CAST_TO(error.userInfo[PowerAuthErrorDomain], PowerAuthRestApiErrorResponse);
+                NSUInteger httpStatusCode = responseObject.httpStatusCode;
+                if (httpStatusCode == 401) {
+                    errorCode = EC_AUTHENTICATION_ERROR;
+                    message = @"Unauthorized";
+                } else {
+                    errorCode = EC_RESPONSE_ERROR;
+                    message = @"Wrong HTTP status code received from the server";
+                }
+                NSMutableDictionary * newUserInfo = [NSMutableDictionary dictionaryWithObject:message forKey:NSLocalizedDescriptionKey];
+                if (responseObject) {
+                    newUserInfo[@"httpStatusCode"] = @(httpStatusCode);
+                    // Serialize dictionary back to string, to be compatible with Android
+                    NSData * jsonData = [NSJSONSerialization dataWithJSONObject:responseData options:0 error:nil];
+                    if (jsonData) {
+                        NSString * jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+                        if (jsonString) {
+                            newUserInfo[@"responseBody"] = jsonString;
+                        }
+                    }
+                    NSString * serverResponseCode = responseObject.responseObject.code;
+                    if (serverResponseCode) {
+                        newUserInfo[@"serverResponseCode"] = serverResponseCode;
+                    }
+                    NSString * serverResponseMessage = responseObject.responseObject.message;
+                    if (serverResponseMessage) {
+                        newUserInfo[@"serverResponseMessage"] = serverResponseMessage;
+                    }
+                    NSInteger recoveryPukIndex = responseObject.responseObject.currentRecoveryPukIndex;
+                    if (recoveryPukIndex > 0) {
+                        newUserInfo[@"currentRecoveryPukIndex"] = @(recoveryPukIndex);
+                    }
+                }
+                // Finally, build a new error
+                error = [NSError errorWithDomain:PowerAuthErrorDomain code:error.code userInfo:newUserInfo];
+                //
+            } else {
+                // Other type of PowerAuthError. Just translate errorCode to string and keep NSError as it is.
+                errorCode = TranslatePAErrorCode(paErrorCode);
+                //
+            }
+        } else if ([error.domain isEqualToString:NSURLErrorDomain]) {
+            // Handle error from NSURLSession
+            errorCode = EC_NETWORK_ERROR;
+            //
+        } else {
+            // We don't know this domain, so translate result as an UNKNOWN_ERROR
+            errorCode = EC_UNKNOWN_ERROR;
+            //
+        }
+    } else {
+        // Error object is nil
+        errorCode = EC_UNKNOWN_ERROR;
+        message = @"Native code failed with unspecified error";
+    }
+    
+    // Finally call promise's reject
+    reject(errorCode, message, error);
+}

--- a/ios/PowerAuth/PowerAuth.m
+++ b/ios/PowerAuth/PowerAuth.m
@@ -922,7 +922,7 @@ RCT_REMAP_METHOD(generateHeaderForToken,
         if (password) {
             return [PowerAuthAuthentication possessionWithPassword:password];
         } else if (useBiometry) {
-            NSString * biometryKeyId = GetNSStringValueFromDict(dict, @"biometryKey");
+            NSString * biometryKeyId = GetNSStringValueFromDict(dict, @"biometryKeyId");
             if (biometryKeyId) {
                 PowerAuthData * biometryKeyData = [_objectRegister useObjectWithId:biometryKeyId expectedClass:[PowerAuthData class]];
                 if (biometryKeyData) {

--- a/ios/PowerAuth/PowerAuth.m
+++ b/ios/PowerAuth/PowerAuth.m
@@ -15,6 +15,9 @@
  */
 
 #import "PowerAuth.h"
+#import "PowerAuthData.h"
+#import "Constants.h"
+
 #import "UIKit/UIKit.h"
 
 #import <React/RCTConvert.h>
@@ -23,57 +26,40 @@
 #import <PowerAuth2/PowerAuthErrorConstants.h>
 #import <PowerAuth2/PowerAuthKeychain.h>
 #import <PowerAuth2/PowerAuthClientSslNoValidationStrategy.h>
-#import <PowerAuth2/PowerAuthRestApiErrorResponse.h>
-
-/**
- Cast object to desired class, or return nil if object is different kind of class.
- */
-static inline id _CastObjectTo(id instance, Class desiredClass) {
-    if ([instance isKindOfClass:desiredClass]) {
-        return instance;
-    }
-    return nil;
-}
-/**
- Macro to cast object to desired class, or return nil if object is different kind of class.
- */
-#define CAST_TO(object, requiredClass) ((requiredClass*)(_CastObjectTo(object, [requiredClass class])))
 
 
 @implementation PowerAuth
 {
-    id<NSLocking> _mutex;
-    NSMutableDictionary<NSString*, PowerAuthSDK*>* _sdkInstances;
+    PowerAuthObjectRegister * _objectRegister;
 }
+
+@synthesize moduleRegistry = _moduleRegistry;
 
 #define PA_BLOCK_START [self usePowerAuth:instanceId reject:reject callback:^(PowerAuthSDK * powerAuth) {
 #define PA_BLOCK_END }];
 
-- (instancetype)init
-{
-    self = [super init];
-    if (self) {
-        _mutex = [[NSLock alloc] init];
-        _sdkInstances = [[NSMutableDictionary alloc] init];
-    }
-    return self;
-}
-
 RCT_EXPORT_MODULE(PowerAuth);
 
-+ (BOOL)requiresMainQueueSetup
+- (void) initialize
+{
+    // RCTInitializing protocol allows us to get module dependencies before the object is used from JS.
+    _objectRegister = [_moduleRegistry moduleForName:"PowerAuthObjectRegister"];
+}
+
++ (BOOL) requiresMainQueueSetup
 {
     return NO;
 }
 
 #pragma mark - React methods
-
 RCT_REMAP_METHOD(isConfigured,
                  instanceId:(NSString *)instanceId
                  isConfiguredResolve:(RCTPromiseResolveBlock)resolve
                  isConfiguredReject:(RCTPromiseRejectBlock)reject)
 {
-    resolve(@([self powerAuthForInstanceId:instanceId] != nil));
+    if ([self validateInstanceId:instanceId reject:reject]) {
+        resolve(@([_objectRegister findObjectWithId:instanceId expectedClass:[PowerAuthSDK class]] != nil));
+    }
 }
 
 RCT_REMAP_METHOD(configure,
@@ -85,8 +71,7 @@ RCT_REMAP_METHOD(configure,
                  configureResolve:(RCTPromiseResolveBlock)resolve
                  configureReject:(RCTPromiseRejectBlock)reject)
 {
-    if (instanceId.length == 0) {
-        reject(@"WRONG_PARAMETER", @"Instance identifier is missing or empty string", nil);
+    if (![self validateInstanceId:instanceId reject:reject]) {
         return;
     }
     
@@ -99,7 +84,7 @@ RCT_REMAP_METHOD(configure,
     config.baseEndpointUrl = CAST_TO(configuration[@"baseEndpointUrl"], NSString);
     
     if (![config validateConfiguration]) {
-        reject(@"WRONG_PARAMETER", @"Provided configuration is invalid", nil);
+        reject(EC_WRONG_PARAMETER, @"Provided configuration is invalid", nil);
         return;
     }
 
@@ -119,7 +104,7 @@ RCT_REMAP_METHOD(configure,
     keychainConfig.allowBiometricAuthenticationFallbackToDevicePasscode = CAST_TO(biometryConfiguration[@"fallbackToDevicePasscode"], NSNumber).boolValue;
 
     // Now register the instance in the thread safe manner.
-    BOOL registered = [self registerPowerAuthForInstanceId:instanceId instanceProvider:^PowerAuthSDK * _Nonnull {
+    BOOL registered = [_objectRegister registerObjectWithId:instanceId tag:instanceId policies:@[RP_MANUAL()] objectFactory:^id {
         return [[PowerAuthSDK alloc] initWithConfiguration:config keychainConfiguration:keychainConfig clientConfiguration:clientConfig];
     }];
     
@@ -128,7 +113,7 @@ RCT_REMAP_METHOD(configure,
         resolve(@YES);
     } else {
         // Instance is already configured
-        reject(@"REACT_NATIVE_ERROR", @"PowerAuth object with this instanceId is already configured.", nil);
+        reject(EC_REACT_NATIVE_ERROR, @"PowerAuth object with this instanceId is already configured.", nil);
     }
 }
 
@@ -137,8 +122,10 @@ RCT_REMAP_METHOD(deconfigure,
                  deconfigureResolve:(RCTPromiseResolveBlock)resolve
                  deconfigureReject:(RCTPromiseRejectBlock)reject)
 {
-    [self unregisterPowerAuthForInstanceId:instanceId];
-    resolve(@YES);
+    if ([self validateInstanceId:instanceId reject:reject]) {
+        [_objectRegister removeAllObjectsWithTag:instanceId];
+        resolve(@YES);
+    }
 }
 
 RCT_REMAP_METHOD(hasValidActivation,
@@ -187,7 +174,7 @@ RCT_REMAP_METHOD(fetchActivationStatus,
             };
             resolve(response);
         } else {
-            [self processError:error with:reject];
+            ProcessError(error, reject);
         }
     }];
     PA_BLOCK_END
@@ -220,7 +207,7 @@ RCT_REMAP_METHOD(createActivation,
     }
     
     if (!paActivation) {
-        reject(@"INVALID_ACTIVATION_OBJECT", @"Activation object is invalid.", nil);
+        reject(EC_INVALID_ACTIVATION_OBJECT, @"Activation object is invalid.", nil);
         return;
     }
     
@@ -238,7 +225,7 @@ RCT_REMAP_METHOD(createActivation,
     
     [powerAuth createActivation:paActivation callback:^(PowerAuthActivationResult * _Nullable result, NSError * _Nullable error) {
         if (error == nil) {
-            resolve(_PatchNull(@{
+            resolve(PatchNull(@{
                 @"activationFingerprint": result.activationFingerprint,
                 @"activationRecovery": result.activationRecovery ? @{
                     @"recoveryCode": result.activationRecovery.recoveryCode,
@@ -247,7 +234,7 @@ RCT_REMAP_METHOD(createActivation,
                 @"customAttributes": result.customAttributes ? result.customAttributes : [NSNull null]
             }));
         } else {
-            [self processError:error with:reject];
+            ProcessError(error, reject);
         }
     }];
     PA_BLOCK_END
@@ -260,7 +247,10 @@ RCT_REMAP_METHOD(commitActivation,
                  commitActivationRejecter:(RCTPromiseRejectBlock)reject)
 {
     PA_BLOCK_START
-    PowerAuthAuthentication *auth = [self constructAuthenticationFromDictionary:authDict forCommit:YES];
+    PowerAuthAuthentication *auth = [self constructAuthenticationFromDictionary:authDict reject:reject forCommit:YES];
+    if (!auth) {
+        return;
+    }
     
     NSError* error = nil;
     bool success = [powerAuth commitActivationWithAuthentication:auth error:&error];
@@ -268,7 +258,7 @@ RCT_REMAP_METHOD(commitActivation,
     if (success) {
         resolve(@YES);
     } else {
-        [self processError:error with:reject];
+        ProcessError(error, reject);
     }
     PA_BLOCK_END
 }
@@ -301,10 +291,12 @@ RCT_REMAP_METHOD(removeActivationWithAuthentication,
                  removeActivationRejecter:(RCTPromiseRejectBlock)reject)
 {
     PA_BLOCK_START
-    PowerAuthAuthentication *auth = [self constructAuthenticationFromDictionary:authDict forCommit:NO];
+    PowerAuthAuthentication *auth = [self constructAuthenticationFromDictionary:authDict reject:reject forCommit:NO];
+    if (!auth) return;
+    
     [powerAuth removeActivationWithAuthentication:auth callback:^(NSError * _Nullable error) {
         if (error) {
-            [self processError:error with:reject];
+            ProcessError(error, reject);
         } else {
             resolve(@YES);
         }
@@ -332,12 +324,14 @@ RCT_REMAP_METHOD(requestGetSignature,
                  requestSignatureReject:(RCTPromiseRejectBlock)reject)
 {
     PA_BLOCK_START
-    PowerAuthAuthentication *auth = [self constructAuthenticationFromDictionary:authDict forCommit:NO];
+    PowerAuthAuthentication *auth = [self constructAuthenticationFromDictionary:authDict reject:reject forCommit:NO];
+    if (!auth) return;
+    
     NSError* error = nil;
     PowerAuthAuthorizationHttpHeader* signature = [powerAuth requestGetSignatureWithAuthentication:auth uriId:uriId params:params error: &error];
     
     if (error) {
-        [self processError:error with:reject];
+        ProcessError(error, reject);
     } else {
         NSDictionary *response = @{
             @"key": signature.key,
@@ -358,13 +352,14 @@ RCT_REMAP_METHOD(requestSignature,
                  requestSignatureReject:(RCTPromiseRejectBlock)reject)
 {
     PA_BLOCK_START
-    PowerAuthAuthentication *auth = [self constructAuthenticationFromDictionary:authDict forCommit:NO];
+    PowerAuthAuthentication *auth = [self constructAuthenticationFromDictionary:authDict reject:reject forCommit:NO];
+    if (!auth) return;
     
     NSError* error = nil;
     PowerAuthAuthorizationHttpHeader* signature = [powerAuth requestSignatureWithAuthentication:auth method:method uriId:uriId body:[RCTConvert NSData:body] error:&error];
     
     if (error) {
-        [self processError:error with:reject];
+        ProcessError(error, reject);
     } else {
         NSDictionary *response = @{
             @"key": signature.key,
@@ -385,12 +380,14 @@ RCT_REMAP_METHOD(offlineSignature,
                  offlineSignatureReject:(RCTPromiseRejectBlock)reject)
 {
     PA_BLOCK_START
-    PowerAuthAuthentication *auth = [self constructAuthenticationFromDictionary:authDict forCommit:NO];
+    PowerAuthAuthentication *auth = [self constructAuthenticationFromDictionary:authDict reject:reject forCommit:NO];
+    if (!auth) return;
+    
     NSError* error = nil;
     NSString* signature = [powerAuth offlineSignatureWithAuthentication:auth uriId:uriId body:[RCTConvert NSData:body] nonce:nonce error:&error];
     
     if (error) {
-        [self processError:error with:reject];
+        ProcessError(error, reject);
     } else {
         resolve(signature);
     }
@@ -407,7 +404,7 @@ RCT_REMAP_METHOD(verifyServerSignedData,
 {
     PA_BLOCK_START
     BOOL result = [powerAuth verifyServerSignedData:[RCTConvert NSData:data] signature:signature masterKey:masterKey];
-    resolve([[NSNumber alloc] initWithBool:result]);
+    resolve(@(result));
     PA_BLOCK_END
 }
 
@@ -420,7 +417,7 @@ RCT_REMAP_METHOD(unsafeChangePassword,
 {
     PA_BLOCK_START
     BOOL result = [powerAuth unsafeChangePasswordFrom:oldPassword to:newPassword];
-    resolve([[NSNumber alloc] initWithBool:result]);
+    resolve(@(result));
     PA_BLOCK_END
 }
 
@@ -434,7 +431,7 @@ RCT_REMAP_METHOD(changePassword,
     PA_BLOCK_START
     [powerAuth changePasswordFrom:oldPassword to:newPassword callback:^(NSError * error) {
         if (error) {
-            [self processError:error with:reject];
+            ProcessError(error, reject);
         } else {
             resolve(@YES);
         }
@@ -449,9 +446,9 @@ RCT_REMAP_METHOD(addBiometryFactor,
                  reject:(RCTPromiseRejectBlock)reject)
 {
     PA_BLOCK_START
-    [powerAuth addBiometryFactor:password callback:^(NSError * error) {
+    [powerAuth addBiometryFactorWithPassword:password callback:^(NSError * error) {
         if (error) {
-            [self processError:error with:reject];
+            ProcessError(error, reject);
         } else {
             resolve(@YES);
         }
@@ -465,7 +462,7 @@ RCT_REMAP_METHOD(hasBiometryFactor,
                  hasBiometryFactorReject:(RCTPromiseRejectBlock)reject)
 {
     PA_BLOCK_START
-    resolve([[NSNumber alloc] initWithBool:[powerAuth hasBiometryFactor]]);
+    resolve(@([powerAuth hasBiometryFactor]));
     PA_BLOCK_END
 }
 
@@ -475,7 +472,7 @@ RCT_REMAP_METHOD(removeBiometryFactor,
                  removeBiometryFactorReject:(RCTPromiseRejectBlock)reject)
 {
     PA_BLOCK_START
-    resolve([[NSNumber alloc] initWithBool:[powerAuth removeBiometryFactor]]);
+    resolve(@([powerAuth removeBiometryFactor]));
     PA_BLOCK_END
 }
 
@@ -532,12 +529,14 @@ RCT_REMAP_METHOD(fetchEncryptionKey,
                  reject:(RCTPromiseRejectBlock)reject)
 {
     PA_BLOCK_START
-    PowerAuthAuthentication *auth = [self constructAuthenticationFromDictionary:authDict forCommit:NO];
+    PowerAuthAuthentication *auth = [self constructAuthenticationFromDictionary:authDict reject:reject forCommit:NO];
+    if (!auth) return;
+    
     [powerAuth fetchEncryptionKey:auth index:index  callback:^(NSData * encryptionKey, NSError * error) {
         if (encryptionKey) {
             resolve([encryptionKey base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed]);
         } else {
-            [self processError:error with:reject];
+            ProcessError(error, reject);
         }
     }];
     PA_BLOCK_END
@@ -551,12 +550,14 @@ RCT_REMAP_METHOD(signDataWithDevicePrivateKey,
                  reject:(RCTPromiseRejectBlock)reject)
 {
     PA_BLOCK_START
-    PowerAuthAuthentication *auth = [self constructAuthenticationFromDictionary:authDict forCommit:NO];
+    PowerAuthAuthentication *auth = [self constructAuthenticationFromDictionary:authDict reject:reject forCommit:NO];
+    if (!auth) return;
+    
     [powerAuth signDataWithDevicePrivateKey:auth data:[RCTConvert NSData:data] callback:^(NSData * signature, NSError * error) {
         if (signature) {
             resolve([RCTConvert NSString:[signature base64EncodedStringWithOptions:0]]);
         } else {
-            [self processError:error with:reject];
+            ProcessError(error, reject);
         }
     }];
     PA_BLOCK_END
@@ -569,9 +570,9 @@ RCT_REMAP_METHOD(validatePassword,
                  validatePasswordReject:(RCTPromiseRejectBlock)reject)
 {
     PA_BLOCK_START
-    [powerAuth validatePasswordCorrect:password callback:^(NSError * error) {
+    [powerAuth validatePassword:password callback:^(NSError * error) {
         if (error) {
-            [self processError:error with:reject];
+            ProcessError(error, reject);
         } else {
             resolve(@YES);
         }
@@ -585,7 +586,7 @@ RCT_REMAP_METHOD(hasActivationRecoveryData,
                  hasActivationRecoveryDataReject:(RCTPromiseRejectBlock)reject)
 {
     PA_BLOCK_START
-    resolve([[NSNumber alloc] initWithBool:[powerAuth hasActivationRecoveryData]]);
+    resolve(@([powerAuth hasActivationRecoveryData]));
     PA_BLOCK_END
 }
 
@@ -596,10 +597,12 @@ RCT_REMAP_METHOD(activationRecoveryData,
                  reject:(RCTPromiseRejectBlock)reject)
 {
     PA_BLOCK_START
-    PowerAuthAuthentication *auth = [self constructAuthenticationFromDictionary:authDict forCommit:NO];
+    PowerAuthAuthentication *auth = [self constructAuthenticationFromDictionary:authDict reject:reject forCommit:NO];
+    if (!auth) return;
+    
     [powerAuth activationRecoveryData:auth callback:^(PowerAuthActivationRecoveryData * data, NSError * error) {
         if (error) {
-            [self processError:error with:reject];
+            ProcessError(error, reject);
         } else {
             NSDictionary *response = @{
                 @"recoveryCode": data.recoveryCode,
@@ -619,10 +622,12 @@ RCT_REMAP_METHOD(confirmRecoveryCode,
                  reject:(RCTPromiseRejectBlock)reject)
 {
     PA_BLOCK_START
-    PowerAuthAuthentication *auth = [self constructAuthenticationFromDictionary:authDict forCommit:NO];
+    PowerAuthAuthentication *auth = [self constructAuthenticationFromDictionary:authDict reject:reject forCommit:NO];
+    if (!auth) return;
+    
     [powerAuth confirmRecoveryCode:recoveryCode authentication:auth callback:^(BOOL alreadyConfirmed, NSError * error) {
         if (error) {
-            [self processError:error with:reject];
+            ProcessError(error, reject);
         } else {
             resolve(alreadyConfirmed ? @YES : @NO);
         }
@@ -633,18 +638,31 @@ RCT_REMAP_METHOD(confirmRecoveryCode,
 
 
 RCT_REMAP_METHOD(authenticateWithBiometry,
-                 instanceId:(NSString*)instanceId
+                 instanceId:(nonnull NSString*)instanceId
                  title:(nonnull NSString*)title // title is here only for API compatibility with android
                  message:(nonnull NSString*)message
+                 makeReusable:(BOOL)makeReusable
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject)
 {
     PA_BLOCK_START
-    [powerAuth authenticateUsingBiometryWithPrompt:message callback:^(PowerAuthAuthentication * authentication, NSError * error) {
+    NSString * messageString = [RCTConvert NSString:message];
+    [powerAuth authenticateUsingBiometryWithPrompt:messageString callback:^(PowerAuthAuthentication * authentication, NSError * error) {
         if (authentication) {
-            resolve([authentication.overridenBiometryKey base64EncodedStringWithOptions:NSDataBase64EncodingEndLineWithLineFeed]);
+            // Allocate native object
+            PowerAuthData * managedData = [[PowerAuthData alloc] initWithData:authentication.overridenBiometryKey cleanup:YES];
+            // If reusable authentication is going to be created, then "keep alive" release policy is applied.
+            // Basically, the data will be available up to 10 seconds from the last access.
+            // If authentication is not reusable, then dispose biometric key after its 1st use. We still need
+            // to combine it with "expire" policy to make sure that key don't remain in memory forever.
+            NSArray * releasePolicy = makeReusable
+                        ? @[ RP_KEEP_ALIVE(BIOMETRY_KEY_KEEP_ALIVE_TIME) ]
+                        : @[ RP_AFTER_USE(1), RP_EXPIRE(BIOMETRY_KEY_KEEP_ALIVE_TIME) ];
+            
+            NSString * managedId = [self->_objectRegister registerObject:managedData tag:instanceId policies:releasePolicy];
+            resolve(managedId);
         } else {
-            [self processError:error with:reject];
+            ProcessError(error, reject);
         }
     }];
     PA_BLOCK_END
@@ -657,12 +675,12 @@ RCT_REMAP_METHOD(parseActivationCode,
 {
     PowerAuthActivationCode *ac = [PowerAuthActivationCodeUtil parseFromActivationCode:activationCode];
     if (ac) {
-        resolve(_PatchNull(@{
+        resolve(PatchNull(@{
             @"activationCode": ac.activationCode,
             @"activationSignature": ac.activationSignature ? ac.activationSignature : [NSNull null]
         }));
     } else {
-        reject(@"INVALID_ACTIVATION_CODE", @"Invalid activation code.", nil);
+        reject(EC_INVALID_ACTIVATION_CODE, @"Invalid activation code.", nil);
     }
 }
 
@@ -681,12 +699,12 @@ RCT_REMAP_METHOD(parseRecoveryCode,
 {
     PowerAuthActivationCode *ac = [PowerAuthActivationCodeUtil parseFromRecoveryCode:recoveryCode];
     if (ac) {
-        resolve(_PatchNull(@{
+        resolve(PatchNull(@{
             @"activationCode": ac.activationCode,
             @"activationSignature": ac.activationSignature ? ac.activationSignature : [NSNull null]
         }));
     } else {
-        reject(@"INVALID_RECOVERY_CODE", @"Invalid recovery code.", nil);
+        reject(EC_INVALID_RECOVERY_CODE, @"Invalid recovery code.", nil);
     }
 }
 
@@ -721,7 +739,7 @@ RCT_REMAP_METHOD(correctTypedCharacter,
 {
     UInt32 corrected = [PowerAuthActivationCodeUtil validateAndCorrectTypedCharacter:utfCodepoint.unsignedIntValue];
     if (corrected == 0) {
-        reject(@"INVALID_CHARACTER", @"Invalid character cannot be corrected.", nil);
+        reject(EC_INVALID_CHARACTER, @"Invalid character cannot be corrected.", nil);
     } else {
         resolve([[NSNumber alloc] initWithInt:corrected]);
     }
@@ -735,10 +753,12 @@ RCT_REMAP_METHOD(requestAccessToken,
                  reject:(RCTPromiseRejectBlock)reject)
 {
     PA_BLOCK_START
-    PowerAuthAuthentication *auth = [self constructAuthenticationFromDictionary:authDict forCommit:NO];
+    PowerAuthAuthentication *auth = [self constructAuthenticationFromDictionary:authDict reject:reject forCommit:NO];
+    if (!auth) return;
+    
     [[powerAuth tokenStore] requestAccessTokenWithName:tokenName authentication:auth completion:^(PowerAuthToken * token, NSError * error) {
         if (error || token == nil) {
-            [self processError:error with:reject];
+            ProcessError(error, reject);
         } else {
             resolve(@{
                 @"tokenName": token.tokenName,
@@ -760,7 +780,7 @@ RCT_REMAP_METHOD(removeAccessToken,
         if (removed) {
             resolve(nil);
         } else {
-            [self processError:error with:reject];
+            ProcessError(error, reject);
         }
     }];
     PA_BLOCK_END
@@ -791,7 +811,7 @@ RCT_REMAP_METHOD(getLocalToken,
             @"tokenIdentifier": token.tokenIdentifier
         });
     } else {
-        reject(@"LOCAL_TOKEN_NOT_AVAILABLE", @"Token with this name is not in the local store.", nil);
+        reject(EC_LOCAL_TOKEN_NOT_AVAILABLE, @"Token with this name is not in the local store.", nil);
     }
     PA_BLOCK_END
 }
@@ -828,7 +848,7 @@ RCT_REMAP_METHOD(generateHeaderForToken,
     PA_BLOCK_START
     PowerAuthToken* token = [[powerAuth tokenStore] localTokenWithName:tokenName];
     if (token == nil) {
-        reject(@"LOCAL_TOKEN_NOT_AVAILABLE", @"This token is no longer available in the local store.", nil);
+        reject(EC_LOCAL_TOKEN_NOT_AVAILABLE, @"This token is no longer available in the local store.", nil);
     }
     else if ([token canGenerateHeader]) {
         PowerAuthAuthorizationHttpHeader* header = [token generateHeader];
@@ -838,73 +858,27 @@ RCT_REMAP_METHOD(generateHeaderForToken,
                 @"value": header.value
             });
         } else {
-            reject(@"CANNOT_GENERATE_TOKEN", @"Cannot generate header for this token.", nil);
+            reject(EC_CANNOT_GENERATE_TOKEN, @"Cannot generate header for this token.", nil);
         }
     } else {
-        reject(@"CANNOT_GENERATE_TOKEN", @"Cannot generate header for this token.", nil);
+        reject(EC_CANNOT_GENERATE_TOKEN, @"Cannot generate header for this token.", nil);
     }
     PA_BLOCK_END
 }
 
-
-#pragma mark - Instances register
-
-/// Method gets PowerAuthSDK instance with given identifier.
-/// @param instanceId PowerAuthSDK instance or nil if there's no such instance with required identifier.
-- (PowerAuthSDK*) powerAuthForInstanceId:(NSString *)instanceId
-{
-    [_mutex lock];
-    PowerAuthSDK * sdk = [_sdkInstances objectForKey:instanceId];
-    [_mutex unlock];
-    return sdk;
-}
-
-/// Method registers PowerAuthSDK instance for given identifier. The SDK instnace must be provided by instanceProvider block.
-/// @param instanceId Instance identifier.
-/// @param instanceProvider Block to construct valid PowerAuthSDK instance.
-- (BOOL) registerPowerAuthForInstanceId:(nonnull NSString*)instanceId
-                       instanceProvider:(PowerAuthSDK * _Nonnull (^ _Nonnull)(void))instanceProvider
-{
-    [_mutex lock];
-    BOOL registered;
-    if (_sdkInstances[instanceId] == nil) {
-        _sdkInstances[instanceId] = instanceProvider();
-        registered = YES;
-    } else {
-        registered = NO;
-    }
-    [_mutex unlock];
-    return registered;
-}
-
-/// Method unregister PowerAuthSDK instnace with given identifier. If there's no such object, then does nothing,
-/// @param instanceId Instance identifier.
-- (void) unregisterPowerAuthForInstanceId:(NSString*)instanceId
-{
-    [_mutex lock];
-    [_sdkInstances removeObjectForKey:instanceId];
-    [_mutex unlock];
-}
-
-
 #pragma mark - Helper methods
 
-/**
- Patch nulls in object to undefined (e.g. remove keys with nulls)
- */
-static id _PatchNull(id object) {
-    if (object == [NSNull null]) {
-        return nil;
+/// Validate instance identifier and call reject promise if identifier is invalid.
+/// @param instanceId Instance identifier to validate.
+/// @param reject Reject block
+/// @return NO if instance identifier is invalid and reject block was called, YES otherwise.
+- (BOOL) validateInstanceId:(NSString*)instanceId reject:(RCTPromiseRejectBlock)reject
+{
+    if (![_objectRegister isValidObjectId: instanceId]) {
+        reject(EC_WRONG_PARAMETER, @"Instance identifier is missing or empty string", nil);
+        return NO;
     }
-    if ([object isKindOfClass:[NSDictionary class]]) {
-        // Key-value dictionary
-        NSMutableDictionary * newObject = [object mutableCopy];
-        [(NSDictionary*)object enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL * stop) {
-            newObject[key] = _PatchNull(value);
-        }];
-        return newObject;
-    }
-    return object;
+    return YES;
 }
 
 /// Method gets PowerAuthSDK instance from instance register and call `callback` with given object.
@@ -916,53 +890,25 @@ static id _PatchNull(id object) {
                reject:(RCTPromiseRejectBlock)reject
              callback:(void(^)(PowerAuthSDK *sdk))callback
 {
-    if (instanceId.length != 0) {
-        PowerAuthSDK* sdk = [self powerAuthForInstanceId:instanceId];
+    if ([self validateInstanceId:instanceId reject:reject]) {
+        PowerAuthSDK* sdk = [_objectRegister findObjectWithId:instanceId expectedClass:[PowerAuthSDK class]];
         if (sdk) {
             callback(sdk);
         } else {
-            reject(@"INSTANCE_NOT_CONFIGURED", @"This instance is not configured.", nil);
+            reject(EC_INSTANCE_NOT_CONFIGURED, @"This instance is not configured.", nil);
         }
-    } else {
-        reject(@"WRONG_PARAMETER", @"Instance identifier is missing or empty string", nil);
     }
-}
-
-/// Extract NSString value from dictionary containing encoded JS object.
-/// @param dict Dictionary containing JS object.
-/// @param key Key for value to extract from the dictionary.
-/// @return String extracted from the dictionary.
-static NSString * _GetNSStringValueFromDict(NSDictionary * dict, NSString * key)
-{
-    id value = dict[key];
-    if (value == nil || value == [NSNull null]) {
-        return nil;
-    }
-    return [RCTConvert NSString:value];
-}
-
-/// Extract NSData value from dictionary containing encoded JS object. The dictionary must contain
-/// Base64 encoded string for the provided key.
-/// @param dict Dictionary containing JS object.
-/// @param key Key for value to extract from the dictionary.
-/// @return NSData extracted from the dictionary.
-static NSData * _GetNSDataValueFromDict(NSDictionary * dict, NSString * key)
-{
-    NSString * encodedData = _GetNSStringValueFromDict(dict, key);
-    if (encodedData) {
-        return [[NSData alloc] initWithBase64EncodedString:encodedData options:NSDataBase64DecodingIgnoreUnknownCharacters];
-    }
-    return nil;
 }
 
 /// Translate dictionary into `PowerAuthAuthentication` object.
 /// @param dict Dictionary with authentication data.
 /// @param commit Set YES if authentication is required for activation commit.
 - (PowerAuthAuthentication*) constructAuthenticationFromDictionary:(NSDictionary*)dict
+                                                            reject:(RCTPromiseRejectBlock)reject
                                                          forCommit:(BOOL)commit
 {
     BOOL useBiometry = [RCTConvert BOOL:dict[@"useBiometry"]];
-    NSString * password = _GetNSStringValueFromDict(dict, @"userPassword");
+    NSString * password = GetNSStringValueFromDict(dict, @"userPassword");
     if (commit) {
         // Activation commit
         if (useBiometry) {
@@ -976,11 +922,17 @@ static NSData * _GetNSDataValueFromDict(NSDictionary * dict, NSString * key)
         if (password) {
             return [PowerAuthAuthentication possessionWithPassword:password];
         } else if (useBiometry) {
-            NSData * biometryKey = _GetNSDataValueFromDict(dict, @"biometryKey");
-            if (biometryKey) {
-                return [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:biometryKey customPossessionKey:nil];
+            NSString * biometryKeyId = GetNSStringValueFromDict(dict, @"biometryKey");
+            if (biometryKeyId) {
+                PowerAuthData * biometryKeyData = [_objectRegister useObjectWithId:biometryKeyId expectedClass:[PowerAuthData class]];
+                if (biometryKeyData) {
+                    return [PowerAuthAuthentication possessionWithBiometryWithCustomBiometryKey:biometryKeyData.data customPossessionKey:nil];
+                } else {
+                    reject(EC_INVALID_NATIVE_OBJECT, @"Biometric key in PowerAuthAuthentication object is no longer valid.", nil);
+                    return nil;
+                }
             }
-            NSString * biometryPrompt = _GetNSStringValueFromDict(dict, @"biometryMessage");
+            NSString * biometryPrompt = GetNSStringValueFromDict(dict, @"biometryMessage");
             if (biometryPrompt) {
                 return [PowerAuthAuthentication possessionWithBiometryPrompt:biometryPrompt];
             } else {
@@ -1005,113 +957,6 @@ static NSData * _GetNSDataValueFromDict(NSDictionary * dict, NSString * key)
         case PowerAuthActivationState_Deadlock: return @"DEADLOCK";
         default: return [[NSString alloc] initWithFormat:@"STATE_UNKNOWN_%li", status];
     }
-}
-
-#pragma mark - Error handling
-
-/// Translates PowerAuthErrorCode into string representation.
-/// @param code Error code to convert.
-static NSString * _TranslatePAErrorCode(PowerAuthErrorCode code)
-{
-    switch (code) {
-        case PowerAuthErrorCode_NetworkError: return @"NETWORK_ERROR";
-        case PowerAuthErrorCode_SignatureError: return @"SIGNATURE_ERROR";
-        case PowerAuthErrorCode_InvalidActivationState: return @"INVALID_ACTIVATION_STATE";
-        case PowerAuthErrorCode_InvalidActivationData: return @"INVALID_ACTIVATION_DATA";
-        case PowerAuthErrorCode_MissingActivation: return @"MISSING_ACTIVATION";
-        case PowerAuthErrorCode_ActivationPending: return @"PENDING_ACTIVATION";
-        case PowerAuthErrorCode_BiometryCancel: return @"BIOMETRY_CANCEL";
-        case PowerAuthErrorCode_OperationCancelled: return @"OPERATION_CANCELED";
-        case PowerAuthErrorCode_InvalidActivationCode: return @"INVALID_ACTIVATION_CODE";
-        case PowerAuthErrorCode_InvalidToken: return @"INVALID_TOKEN";
-        case PowerAuthErrorCode_Encryption: return @"ENCRYPTION_ERROR";
-        case PowerAuthErrorCode_WrongParameter: return @"WRONG_PARAMETER";
-        case PowerAuthErrorCode_ProtocolUpgrade: return @"PROTOCOL_UPGRADE";
-        case PowerAuthErrorCode_PendingProtocolUpgrade: return @"PENDING_PROTOCOL_UPGRADE";
-        case PowerAuthErrorCode_BiometryNotAvailable: return @"BIOMETRY_NOT_AVAILABLE";
-        case PowerAuthErrorCode_WatchConnectivity: return @"WATCH_CONNECTIVITY";
-        case PowerAuthErrorCode_BiometryFailed: return @"BIOMETRY_FAILED";
-        default: return [[NSString alloc] initWithFormat:@"UNKNOWN_%li", code];
-    }
-}
-
-/// Method translate reported NSError into proper React Native error code and reports everything back promise reject block.
-/// @param error Error to report.
-/// @param reject Reject promise to call.
-- (void) processError:(nullable NSError*)error with:(nonnull RCTPromiseRejectBlock)reject
-{
-    NSString * errorCode = nil;
-    NSString * message;
-    if (error != nil) {
-        // Keep message
-        message = error.localizedDescription;
-        // If powerAuthErrorCode is different than .NA, then it's PowerAuthDomain error.
-        PowerAuthErrorCode paErrorCode = error.powerAuthErrorCode;
-        if (paErrorCode != PowerAuthErrorCode_NA) {
-            // Handle PA error
-            NSDictionary * responseData = CAST_TO(error.userInfo[PowerAuthErrorInfoKey_AdditionalInfo], NSDictionary);
-            if (responseData != nil) {
-                // Handle error response received from the server. In this case, we have to re-create a new NSError, because
-                // React Native layer cannot translate our custom objects, stored in NSError. So, we have to create a new userInfo with
-                // a plain serializable data.
-                PowerAuthRestApiErrorResponse * responseObject = CAST_TO(error.userInfo[PowerAuthErrorDomain], PowerAuthRestApiErrorResponse);
-                NSUInteger httpStatusCode = responseObject.httpStatusCode;
-                if (httpStatusCode == 401) {
-                    errorCode = @"AUTHENTICATION_ERROR";
-                    message = @"Unauthorized";
-                } else {
-                    errorCode = @"RESPONSE_ERROR";
-                    message = @"Wrong HTTP status code received from the server";
-                }
-                NSMutableDictionary * newUserInfo = [NSMutableDictionary dictionaryWithObject:message forKey:NSLocalizedDescriptionKey];
-                if (responseObject) {
-                    newUserInfo[@"httpStatusCode"] = @(httpStatusCode);
-                    // Serialize dictionary back to string, to be compatible with Android
-                    NSData * jsonData = [NSJSONSerialization dataWithJSONObject:responseData options:0 error:nil];
-                    if (jsonData) {
-                        NSString * jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-                        if (jsonString) {
-                            newUserInfo[@"responseBody"] = jsonString;
-                        }
-                    }
-                    NSString * serverResponseCode = responseObject.responseObject.code;
-                    if (serverResponseCode) {
-                        newUserInfo[@"serverResponseCode"] = serverResponseCode;
-                    }
-                    NSString * serverResponseMessage = responseObject.responseObject.message;
-                    if (serverResponseMessage) {
-                        newUserInfo[@"serverResponseMessage"] = serverResponseMessage;
-                    }
-                    NSInteger recoveryPukIndex = responseObject.responseObject.currentRecoveryPukIndex;
-                    if (recoveryPukIndex > 0) {
-                        newUserInfo[@"currentRecoveryPukIndex"] = @(recoveryPukIndex);
-                    }
-                }
-                // Finally, build a new error
-                error = [NSError errorWithDomain:PowerAuthErrorDomain code:error.code userInfo:newUserInfo];
-                //
-            } else {
-                // Other type of PowerAuthError. Just translate errorCode to string and keep NSError as it is.
-                errorCode = _TranslatePAErrorCode(paErrorCode);
-                //
-            }
-        } else if ([error.domain isEqualToString:NSURLErrorDomain]) {
-            // Handle error from NSURLSession
-            errorCode = @"NETWORK_ERROR";
-            //
-        } else {
-            // We don't know this domain, so translate result as an UNKNOWN_ERROR
-            errorCode = @"UNKNOWN_ERROR";
-            //
-        }
-    } else {
-        // Error object is nil
-        errorCode = @"UNKNOWN_ERROR";
-        message = @"Native code failed with unspecified error";
-    }
-    
-    // Finally call promise's reject
-    reject(errorCode, message, error);
 }
 
 @end

--- a/ios/PowerAuth/PowerAuthData.h
+++ b/ios/PowerAuth/PowerAuthData.h
@@ -1,5 +1,5 @@
-/**
- * Copyright 2020 Wultra s.r.o.
+/*
+ * Copyright 2022 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,20 @@
  * limitations under the License.
  */
 
-#import <React/RCTBridgeModule.h>
-#import <React/RCTInitializing.h>
-#import "PowerAuthObjectRegister.h"
+#import "Utilities.h"
 
-@interface PowerAuth: NSObject<RCTBridgeModule, RCTInitializing>
+/**
+ Object that wrap NSData to JavaScript.
+ */
+@interface PowerAuthData : NSObject
+
+/// Initialize object with NSData object.
+/// - Parameters:
+///   - data: Data object to manage from JavaScript
+///   - cleanup: Do data cleanup if possible.
+- (nonnull instancetype) initWithData:(nonnull NSData*)data cleanup:(BOOL)cleanup;
+
+/// Contains managed data object.
+@property (nonatomic, readonly, strong, nonnull) NSData * data;
 
 @end

--- a/ios/PowerAuth/PowerAuthData.m
+++ b/ios/PowerAuth/PowerAuthData.m
@@ -1,5 +1,5 @@
-/**
- * Copyright 2020 Wultra s.r.o.
+/*
+ * Copyright 2022 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,33 @@
  * limitations under the License.
  */
 
-#import <React/RCTBridgeModule.h>
-#import <React/RCTInitializing.h>
-#import "PowerAuthObjectRegister.h"
+#import "PowerAuthData.h"
+#import "Utilities.h"
 
-@interface PowerAuth: NSObject<RCTBridgeModule, RCTInitializing>
+@implementation PowerAuthData
+{
+    BOOL _cleanup;
+}
+
+- (instancetype) initWithData:(nonnull NSData*)data
+                      cleanup:(BOOL)cleanup
+{
+    self = [super init];
+    if (self) {
+        _data = data;
+        _cleanup = cleanup;
+    }
+    return self;
+}
+
+- (void) dealloc
+{
+    if (_cleanup) {
+        NSMutableData * mutable = CAST_TO(_data, NSMutableData);
+        if (mutable) {
+            memset(mutable.mutableBytes, 0, mutable.length);
+        }
+    }
+}
 
 @end

--- a/ios/PowerAuth/PowerAuthObjectRegister+JS.m
+++ b/ios/PowerAuth/PowerAuthObjectRegister+JS.m
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2022 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "PowerAuthObjectRegister.h"
+#import "PowerAuthData.h"
+
+#import <React/RCTConvert.h>
+#import <React/RCTInvalidating.h>
+
+/*
+ This class category exports several debug methods to JavaScript.
+ The 'debug' methods are available only if library is compiled in DEBUG configuration.
+ */
+@interface PowerAuthObjectRegister (JS) <RCTInvalidating>
+@end
+
+@implementation PowerAuthObjectRegister (JS)
+
+// MARK: - JS interface
+
+- (void) invalidate
+{
+    // RCTInvalidating
+    // This is invoked by RN bridge when devmode reload is requested.
+    // We should remove all objects from the register.
+    [self removeAllObjectsWithTag:nil];
+}
+
++ (BOOL) requiresMainQueueSetup
+{
+    return NO;
+}
+
+RCT_EXPORT_METHOD(isValidNativeObject:(id)objectId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    resolve(@([self containsObjectWithId:objectId]));
+}
+
+#if DEBUG
+
+// MARK: - JS DEBUG
+
+RCT_EXPORT_METHOD(debugDump:(id)instanceId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    resolve([self debugDumpObjectsWithTag:[RCTConvert NSString:instanceId]]);
+}
+
+RCT_EXPORT_METHOD(debugCommand:(NSString*)command
+                  options:(NSDictionary*)options
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    NSString * objectId     = [RCTConvert NSString:options[@"objectId"]];
+    NSString * objectTag    = [RCTConvert NSString:options[@"objectTag"]];
+    NSString * objectType   = [RCTConvert NSString:options[@"objectType"]];
+    Class objectClass = Nil;
+    if ([@"data" isEqual:objectType] || [@"secure-data" isEqual:objectType]) {
+        objectClass = [PowerAuthData class];
+    }
+    if ([@"create" isEqual:command]) {
+        // The "create" command creates a new instance of managed object
+        // and returns its ID to JavaScript.
+        
+        // Prepare Release policy
+        NSMutableArray * policies = [NSMutableArray array];
+        [[RCTConvert NSStringArray:options[@"releasePolicy"]] enumerateObjectsUsingBlock:^(NSString * policy, NSUInteger idx, BOOL * stop) {
+            NSArray * components = [policy componentsSeparatedByString:@" "];
+            NSInteger param = [[components lastObject] integerValue];
+            if ([@"manual" isEqualToString:policy]) {
+                [policies addObject:RP_MANUAL()];
+            } else if ([policy hasPrefix:@"afterUse"]) {
+                [policies addObject:RP_AFTER_USE(param)];
+            } else if ([policy hasPrefix:@"keepAlive"]) {
+                [policies addObject:RP_KEEP_ALIVE(param)];
+            } else if ([policy hasPrefix:@"expire"]) {
+                [policies addObject:RP_EXPIRE(param)];
+            }
+        }];
+        if (policies.count > 0) {
+            // Create new object
+            id instance = nil;
+            if ([@"data" isEqual:objectType]) {
+                NSData * td = [@"TEST-DATA" dataUsingEncoding:NSUTF8StringEncoding];
+                instance = [[PowerAuthData alloc] initWithData:td cleanup:NO];
+            } else if ([@"secure-data" isEqual:objectType]) {
+                NSData * td = [[@"SECURE-DATA" dataUsingEncoding:NSUTF8StringEncoding] mutableCopy];
+                instance = [[PowerAuthData alloc] initWithData:td cleanup:YES];
+            }
+            if (instance) {
+                NSString * objectId = [self registerObject:instance tag:objectTag policies:policies];
+                resolve(objectId);
+                return;
+            }
+        }
+    } else if ([@"release" isEqual:command]) {
+        // The "release" command release object with given identifier and returns true / false whether object was removed.
+        if (objectClass && objectId) {
+            resolve([self removeObjectWithId:objectId expectedClass:objectClass] != nil ? @YES : @NO);
+            return;
+        }
+    } else if ([@"releaseAll" isEqual:command]) {
+        // The "releaseAll" command release all objects with a specified tag. If tag is nil, then releases all objects
+        // from the register.
+        [self removeAllObjectsWithTag:objectTag];
+        resolve(nil);
+        return;
+    } else if ([@"use" isEqual:command]) {
+        // The "use" command find object and mark it as used and returns true / false whether object was found.
+        if (objectClass && objectId) {
+            resolve([self useObjectWithId:objectId expectedClass:objectClass] != nil ? @YES : @NO);
+            return;
+        }
+    } else if ([@"find" isEqual:command]) {
+        // The "find" command just find the object in the register and returns true / false.
+        if (objectClass && objectId) {
+            resolve([self findObjectWithId:objectId expectedClass:objectClass] != nil ? @YES : @NO);
+            return;
+        }
+    } else if ([@"setPeriod" isEqual:command]) {
+        [self setCleanupPeriod:[[RCTConvert NSNumber:options[@"cleanupPeriod"]] integerValue]];
+        resolve(nil);
+        return;
+    }
+    reject(EC_WRONG_PARAMETER, [NSString stringWithFormat:@"Wrong parameter for cmd %@, %@", command, options], nil);
+}
+
+#else
+
+// MARK: - JS RELEASE
+
+RCT_EXPORT_METHOD(debugDump:(id)instanceId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    resolve(nil);
+}
+
+RCT_EXPORT_METHOD(debugCommand:(NSString*)command
+                  options:(NSDictionary*)options
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    resolve(nil);
+}
+#endif // DEBUG
+
+@end

--- a/ios/PowerAuth/PowerAuthObjectRegister.h
+++ b/ios/PowerAuth/PowerAuthObjectRegister.h
@@ -21,7 +21,7 @@
 /**
  Object register that allows us to expose native objects into JavaScript world.
  The object is identified by an unique identifier created at the time of registration
- or by 
+ or by application provided identifier.
  */
 @interface PowerAuthObjectRegister : NSObject<RCTBridgeModule>
 
@@ -86,14 +86,14 @@
 - (BOOL) isValidObjectId:(nullable id)objectId;
 
 /**
- Returns dictionary with debug information about objects stored in the register. The method is available only
+ Returns array with debug information about objects stored in the register. The method is available only
  if library is compiled in DEBUG configuration.
  */
-- (nullable NSDictionary<NSString*, NSString*>*) debugDumpObjectsWithTag:(nullable NSString*)tag;
+- (nonnull NSArray<NSDictionary*>*) debugDumpObjectsWithTag:(nullable NSString*)tag;
 
 /**
  Set interval for internal cleanup job that removes objects that are not valid.
- Only the values in range 100 to 60000ms is accepted. If 0 is provided, then register sets
+ Only the value in range 100 to 60000ms is accepted. If 0 is provided, then register sets
  interval to the default period.
  */
 - (void) setCleanupPeriod:(NSInteger)periodInMs;

--- a/ios/PowerAuth/PowerAuthObjectRegister.h
+++ b/ios/PowerAuth/PowerAuthObjectRegister.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2022 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <React/RCTBridgeModule.h>
+#import <React/RCTInvalidating.h>
+#import "Errors.h"
+
+/**
+ Object register that allows us to expose native objects into JavaScript world.
+ The object is identified by an unique identifier created at the time of registration
+ or by 
+ */
+@interface PowerAuthObjectRegister : NSObject<RCTBridgeModule>
+
+/**
+ Register object and return auto generated object identifier.
+ */
+- (nonnull NSString*) registerObject:(nonnull id)object
+                                 tag:(nullable NSString*)tag
+                            policies:(NSArray<NSNumber*>*_Nonnull)policies;
+/**
+ Register object with application specific identifier. Returns NO if such object is already
+ registered.
+ */
+- (BOOL) registerObject:(nonnull id)object
+                 withId:(nonnull NSString*)objectId
+                    tag:(nullable NSString*)tag
+               policies:(NSArray<NSNumber*>*_Nonnull)policies;
+/**
+ Register object returned from object factory with application specific identifier. Returns NO if such object
+ is already registered or if the factory returns nil.
+ */
+- (BOOL) registerObjectWithId:(nonnull NSString*)objectId
+                          tag:(nullable NSString*)tag
+                     policies:(NSArray<NSNumber*>*_Nonnull)policies
+                objectFactory:(id _Nullable (^ _Nonnull)(void))objectFactory;
+
+/**
+ Find object with given identifier. The identifier may be auto-generated or application specific.
+ This method doesn't increase object's usage count, so it will not cause an object relase.
+ */
+- (nullable id) findObjectWithId:(nonnull NSString*)objectId
+                   expectedClass:(nonnull Class)expectedClass;
+
+/**
+ Find object with given identifier and increase its usage counter.
+ */
+- (nullable id) useObjectWithId:(nonnull NSString*)objectId
+                  expectedClass:(nonnull Class)expectedClass;
+
+/**
+ Returns true if object with given identifier is still valid. Unlike find method, this
+ doesn't require Class to validate the object existence.
+ */
+- (BOOL) containsObjectWithId:(nonnull NSString*)objectId;
+
+
+/**
+ Remove all object with given tag. If tag is not specified, then remove all objects.
+ */
+- (void) removeAllObjectsWithTag:(nullable NSString*)tag;
+
+/**
+ Remove object with given identifier. The identifier may be auto-generated or application specific.
+ Return instance of just removed object or nil if no such object was found.
+ */
+- (nullable id) removeObjectWithId:(nonnull NSString*)objectId expectedClass:(nonnull Class)expectedClass;
+
+/**
+ Validate whether provided object is a valid application specific object identifier. The object ID can be invalid
+ in case that it's not provided, is empty string or identifier collide with an internal implementation.
+ */
+- (BOOL) isValidObjectId:(nullable id)objectId;
+
+/**
+ Returns dictionary with debug information about objects stored in the register. The method is available only
+ if library is compiled in DEBUG configuration.
+ */
+- (nullable NSDictionary<NSString*, NSString*>*) debugDumpObjectsWithTag:(nullable NSString*)tag;
+
+/**
+ Set interval for internal cleanup job that removes objects that are not valid.
+ Only the values in range 100 to 60000ms is accepted. If 0 is provided, then register sets
+ interval to the default period.
+ */
+- (void) setCleanupPeriod:(NSInteger)periodInMs;
+
+@end
+
+/**
+ Creates a new release policy configured to a manual release. This type of policy
+ cannot be combined with other policy types, because the object owner manages the object's
+ lifetime.
+ */
+PA_EXTERN_C NSNumber * _Nonnull RP_MANUAL(void);
+/**
+ Creates a new release policy configured to release object after expected amount of use.
+ It's recommended to combine this type of policy with `RP_EXPIRE()` to make sure
+ that object is always released from the memory.
+ */
+PA_EXTERN_C NSNumber * _Nonnull RP_AFTER_USE(NSUInteger usageCount);
+/**
+ Creates a new release policy configured to release object after a required time of inactivity.
+ The inactivity means that no JavaScript call interacted with the object in the defined
+ time window.
+ */
+PA_EXTERN_C NSNumber * _Nonnull RP_KEEP_ALIVE(NSUInteger timeIntervalMs);
+/**
+ Creates a new release policy configured to release object after a required time.
+ */
+PA_EXTERN_C NSNumber * _Nonnull RP_EXPIRE(NSUInteger timeIntervalMs);

--- a/ios/PowerAuth/PowerAuthObjectRegister.m
+++ b/ios/PowerAuth/PowerAuthObjectRegister.m
@@ -15,6 +15,7 @@
  */
 
 #import "PowerAuthObjectRegister.h"
+#import "Constants.h"
 #import <React/RCTConvert.h>
 
 // MARK: - Release policies -
@@ -134,7 +135,7 @@ static NSString * const _OwnIdPrefix       = @"08]3[7^";
         _lock = dispatch_semaphore_create(1);
         _register = [NSMutableDictionary dictionaryWithCapacity:16];
         _scheduledCleanup = NO;
-        _cleanupPeriod = 10000; // 10 seconds in ms
+        _cleanupPeriod = CLEANUP_PERIOD_DEFAULT;
     }
     return self;
 }
@@ -232,10 +233,10 @@ static NSString * const _OwnIdPrefix       = @"08]3[7^";
 - (void) setCleanupPeriod:(NSInteger)period
 {
     [self synchronizedVoid:^{
-        if (period >= 100 && period <= 60000) {
+        if (period >= CLEANUP_PERIOD_MIN && period <= CLEANUP_PERIOD_MAX) {
             _cleanupPeriod = period;
         } else {
-            _cleanupPeriod = 10000;
+            _cleanupPeriod = CLEANUP_PERIOD_DEFAULT;
         }
         // Kick the cleanup now, because we don't want to wait for the next
         // tick if period is shorter.
@@ -385,7 +386,7 @@ static NSString * const _OwnIdPrefix       = @"08]3[7^";
         return content;
     }];
 #else
-    return @{};
+    return @[];
 #endif
 }
 

--- a/ios/PowerAuth/PowerAuthObjectRegister.m
+++ b/ios/PowerAuth/PowerAuthObjectRegister.m
@@ -1,0 +1,528 @@
+/*
+ * Copyright 2022 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "PowerAuthObjectRegister.h"
+#import <React/RCTConvert.h>
+
+// MARK: - Release policies -
+
+/**
+ Defines how managed object is dereferenced.
+ */
+typedef NS_ENUM(NSUInteger, ReleasePolicyType) {
+    /// Object is manually released. Overrides all other possible policies.
+    RPT_Manual,
+    /// Object is released after use. The number of use attemtps
+    /// is specified in `maxUsageCount` parameter.
+    RPT_AfterUse,
+    /// Object is kept alive for a specified time interval, since
+    /// the last use.
+    RPT_KeepAlive,
+    /// Object is released automatically after the time interval
+    /// specified in `timeInterval` paramter.
+    RPT_Expire
+};
+
+/**
+ Defines release policy for managed object.
+ */
+typedef struct ReleasePolicy {
+    union {
+        struct {
+            ReleasePolicyType policyType  : 8;
+            NSUInteger        policyParam : 24;
+        } policy;
+        NSUInteger numericValue;
+    };
+
+} ReleasePolicy;
+
+NSNumber * RP_MANUAL(void) {
+    ReleasePolicy rp = { 0 };
+    rp.policy.policyType = RPT_Manual;
+    return @(rp.numericValue);
+}
+
+NSNumber * RP_AFTER_USE(NSUInteger usageCount) {
+    ReleasePolicy rp = { 0 };
+    rp.policy.policyType = RPT_AfterUse;
+    rp.policy.policyParam = usageCount;
+    return @(rp.numericValue);
+}
+
+NSNumber * RP_KEEP_ALIVE(NSUInteger timeIntervalMs) {
+    ReleasePolicy rp = { 0 };
+    rp.policy.policyType = RPT_KeepAlive;
+    rp.policy.policyParam = timeIntervalMs;
+    return @(rp.numericValue);
+}
+
+NSNumber * RP_EXPIRE(NSUInteger timeIntervalMs) {
+    ReleasePolicy rp = { 0 };
+    rp.policy.policyType = RPT_Expire;
+    rp.policy.policyParam = timeIntervalMs;
+    return @(rp.numericValue);
+}
+
+static NSString * _GetRandomString(NSUInteger length)
+{
+    NSMutableData * data = [NSMutableData dataWithLength:length];
+    arc4random_buf(data.mutableBytes, data.length);
+    return [data base64EncodedStringWithOptions:0];
+}
+
+
+// MARK: - Managed Object Interface -
+
+@interface PowerAuthManagedObject : NSObject
+
+- (instancetype) initWithObject:(id)object
+                            key:(NSString*)key
+                            tag:(NSString*)tag
+                       policies:(NSArray<NSNumber*>*)policies;
+
+@property (nonatomic, nonnull, readonly, strong) id object;
+@property (nonatomic, nonnull, readonly, strong) NSString * key;
+@property (nonatomic, nonnull, readonly, strong) NSString * tag;
+@property (nonatomic, readonly) NSUInteger usageCount;
+@property (nonatomic, nonnull, readonly) NSDate * createDate;
+@property (nonatomic, nonnull, readonly) NSDate * lastUseDate;
+
+- (BOOL) setUsed;
+- (BOOL) isStillValid;
+- (NSDictionary*) debugDump;
+
+@end
+
+
+// MARK: - Object Manger Implementation -
+
+@implementation PowerAuthObjectRegister
+{
+    dispatch_semaphore_t _lock;
+    NSMutableDictionary<NSString*, PowerAuthManagedObject*> * _register;
+    BOOL _scheduledCleanup;
+    NSInteger _cleanupPeriod;
+}
+
+RCT_EXPORT_MODULE(PowerAuthObjectRegister);
+
+static NSString * const _GeneratedIdPrefix = @"N47|V3^";
+static NSString * const _OwnIdPrefix       = @"08]3[7^";
+
+#define OPT_NONE        0           // no options
+#define OPT_SET_USE     (1 << 0)    // set object as used
+#define OPT_REMOVE      (1 << 1)    // remove object
+
+- (instancetype) init
+{
+    self = [super init];
+    if (self) {
+        _lock = dispatch_semaphore_create(1);
+        _register = [NSMutableDictionary dictionaryWithCapacity:16];
+        _scheduledCleanup = NO;
+        _cleanupPeriod = 10000; // 10 seconds in ms
+    }
+    return self;
+}
+
+// MARK: - Native interface
+
+- (NSString*) registerObject:(id)object tag:(NSString*)tag policies:(NSArray<NSNumber *> *)policies
+{
+    return [self synchronized:^id{
+        NSString * identifier = [self generateIdentifier];
+        PowerAuthManagedObject * managedObject = [[PowerAuthManagedObject alloc] initWithObject:object key:identifier tag:tag policies:policies];
+        _register[identifier] = managedObject;
+        [self scheduleClenaup];
+        return identifier;
+    }];
+}
+
+- (BOOL) registerObject:(id)object withId:(NSString*)objectId tag:(NSString*)tag policies:(NSArray<NSNumber*>*)policies
+{
+    return [self registerObjectWithId:objectId tag:tag policies:policies objectFactory:^id{
+        return object;
+    }];
+}
+
+- (BOOL) registerObjectWithId:(NSString*)objectId tag:(NSString*)tag policies:(NSArray<NSNumber*>*)policies objectFactory:(id(^)(void))objectFactory
+{
+    if (![self isValidObjectId:objectId]) {
+        return NO;
+    }
+    return [[self synchronized:^id{
+        NSString * registeredId = [self translateObjectId:objectId];
+        if ([_register objectForKey:registeredId] != nil) {
+            return @NO;
+        }
+        id object = objectFactory();
+        if (!object) {
+            return @NO;
+        }
+        PowerAuthManagedObject * managedObject = [[PowerAuthManagedObject alloc] initWithObject:object key:objectId tag:tag policies:policies];
+        _register[registeredId] = managedObject;
+        [self scheduleClenaup];
+        return @YES;
+    }] boolValue];
+}
+
+- (id) useObjectWithId:(NSString *)objectId expectedClass:(Class)expectedClass
+{
+    return [self synchronized:^id{
+        return [self findManagedObject:objectId expectedClass:expectedClass options:OPT_SET_USE];
+    }];
+}
+
+- (id) findObjectWithId:(NSString *)objectId expectedClass:(Class)expectedClass
+{
+    return [self synchronized:^id{
+        return [self findManagedObject:objectId expectedClass:expectedClass options:0];
+    }];
+}
+
+- (BOOL) containsObjectWithId:(nonnull NSString*)objectId
+{
+    return [[self synchronized:^id{
+        return @([self findManagedObject:objectId expectedClass:Nil options:0] != nil);
+    }] boolValue];
+}
+
+- (void) removeAllObjectsWithTag:(NSString *)tag
+{
+    return [self synchronizedVoid:^{
+        [self findAndRemoveObjects:^BOOL(NSString *key, PowerAuthManagedObject *obj) {
+            return tag ? [obj.tag isEqualToString:tag] : YES;
+        }];
+    }];
+}
+
+- (id) removeObjectWithId:(NSString*)objectId expectedClass:(Class)expectedClass
+{
+    return [self synchronized:^{
+        return [self findManagedObject:objectId expectedClass:expectedClass options:OPT_REMOVE];
+    }];
+}
+
+- (BOOL) isValidObjectId:(id)objectId
+{
+    NSString * stringId = CAST_TO(objectId, NSString);
+    if (stringId.length == 0) {
+        return NO;
+    }
+    if ([stringId hasPrefix:_GeneratedIdPrefix] || [stringId hasPrefix:_OwnIdPrefix]) {
+        return NO;
+    }
+    return YES;
+}
+
+- (void) setCleanupPeriod:(NSInteger)period
+{
+    [self synchronizedVoid:^{
+        if (period >= 100 && period <= 60000) {
+            _cleanupPeriod = period;
+        } else {
+            _cleanupPeriod = 10000;
+        }
+        // Kick the cleanup now, because we don't want to wait for the next
+        // tick if period is shorter.
+        [self doCleanup];
+    }];
+}
+
+// MARK: - Private
+
+/// Execute block when internal mutex is acquired.
+/// - Parameter block: Block to execute.
+/// - Returns: Value returned from the block.
+- (id) synchronized:(NS_NOESCAPE id(^)(void))block
+{
+    dispatch_semaphore_wait(_lock, DISPATCH_TIME_FOREVER);
+    id result = block();
+    dispatch_semaphore_signal(_lock);
+    return result;
+}
+
+/// Execute void block when internal mutex is acquired.
+/// - Parameter block: Block to execute.
+- (void) synchronizedVoid:(NS_NOESCAPE void(^)(void))block
+{
+    dispatch_semaphore_wait(_lock, DISPATCH_TIME_FOREVER);
+    block();
+    dispatch_semaphore_signal(_lock);
+}
+
+
+/// Translate generated object ID or application specific object ID into
+/// key to register. The function also handles possible invalid, or null
+/// objects are passed from JavaScript by accident.
+///
+/// - Parameter objectId: Object ID to translate.
+/// - Returns: Translated key to object register.
+- (NSString*) translateObjectId:(id)objectId
+{
+    NSString * stringId = [RCTConvert NSString:objectId];
+    if (stringId.length == 0) {
+        return nil;
+    }
+    if ([stringId hasPrefix:_GeneratedIdPrefix]) {
+        return objectId;
+    }
+    return [_OwnIdPrefix stringByAppendingString:stringId];
+}
+
+/// Find object in the object register.
+/// - Parameters:
+///   - objectId: Generated or application specific object register.
+///   - expectedClass: Expected class to retrieve. If not provided, then the stored object can be anything.
+///   - options: Additional operations that will be performed with the object. See `OPT_*` macros for more details.
+/// - Returns: Object retrieved from the register or nil if no such object exist.
+- (id) findManagedObject:(NSString*)objectId expectedClass:(Class)expectedClass options:(NSInteger)options
+{
+    NSString * registeredId = [self translateObjectId:objectId];
+    if (registeredId) {
+        PowerAuthManagedObject * managedObject = _register[registeredId];
+        if (managedObject) {
+            if (expectedClass == Nil || [managedObject.object isKindOfClass:expectedClass]) {
+                if ([managedObject isStillValid]) {
+                    // Still valid. Mark as used and then return the object.
+                    if (options & OPT_SET_USE) {
+                        // Set object as used.
+                        [managedObject setUsed];
+                    } else if (options & OPT_REMOVE) {
+                        // Remove object from the register.
+                        [_register removeObjectForKey:registeredId];
+                    }
+                    return managedObject.object;
+                }
+            }
+        }
+    }
+    return nil;
+}
+
+/// Schedule an object cleanup job.
+- (void) scheduleClenaup
+{
+    if (!_scheduledCleanup && _register.count > 0) {
+        _scheduledCleanup = YES;
+        // Wake-up after cleanup period seconds and do the cleanup.
+        dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, _cleanupPeriod * NSEC_PER_MSEC);
+        dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+        dispatch_after(when, queue, ^{
+            [self synchronizedVoid:^{
+                [self doCleanup];
+            }];
+        });
+    }
+}
+
+/// Function remove expired or no loner valid objects from the register.
+- (void) doCleanup
+{
+    // Clear scheduled flag.
+    _scheduledCleanup = NO;
+    // Remove all invalid objects
+    [self findAndRemoveObjects:^BOOL(NSString *key, PowerAuthManagedObject *obj) {
+        return ![obj isStillValid];
+    }];
+    // Schedule cleanup for the next round
+    [self scheduleClenaup];
+}
+
+/// Function find and remove objects from the register. The provided block decide whether object
+/// needs to be removed.
+/// - Parameter block: Block that decide whether object needs to be removed.
+- (void) findAndRemoveObjects:(NS_NOESCAPE BOOL(^)(NSString * key, PowerAuthManagedObject * obj))block
+{
+    // Find objects that should be removed
+    NSMutableArray * objectsToRemove = [NSMutableArray array];
+    [_register enumerateKeysAndObjectsUsingBlock:^(NSString * key, PowerAuthManagedObject * obj, BOOL * stop) {
+        if (block(key, obj)) {
+            [objectsToRemove addObject:key];
+        }
+    }];
+    // Remove objects found in the previous step.
+    [_register removeObjectsForKeys:objectsToRemove];
+}
+
+/// Generate a new object identifier.
+/// - Returns: New unique object identifier.
+- (NSString*) generateIdentifier
+{
+    while(true) {
+        NSString * identifier = [_GeneratedIdPrefix stringByAppendingString:_GetRandomString(9)];
+        if (![_register objectForKey:identifier]) {
+            return identifier;
+        }
+    }
+}
+
+- (NSArray<NSDictionary*>*) debugDumpObjectsWithTag:(nullable NSString*)tag
+{
+#if DEBUG
+    return [self synchronized:^{
+        NSMutableArray * content = [NSMutableArray arrayWithCapacity:_register.count];
+        [_register enumerateKeysAndObjectsUsingBlock:^(NSString * key, PowerAuthManagedObject * obj, BOOL * stop) {
+            if (tag && (!obj.tag || ![obj.tag isEqualToString:tag])) {
+                return;
+            }
+            [content addObject:[obj debugDump]];
+        }];
+        return content;
+    }];
+#else
+    return @{};
+#endif
+}
+
+#if DEBUG
+- (NSString*) description
+{
+    return [[self debugDumpObjectsWithTag:nil] description];
+}
+#endif // DEBUG
+
+@end
+
+
+// MARK: - Managed Object Implementation -
+
+@implementation PowerAuthManagedObject
+{
+    BOOL          _managedByOwner;
+    NSUInteger    _policiesCount;
+    ReleasePolicy _policies[4];
+}
+
+- (instancetype) initWithObject:(id)object key:(NSString*)key tag:(NSString*)tag policies:(NSArray<NSNumber *> *)policies
+{
+    self = [super init];
+    if (self) {
+        _object = object;
+        _key = key;
+        _tag = tag;
+        _usageCount = 0;
+        _createDate = [NSDate date];
+        _lastUseDate = _createDate;
+        // Update policies array
+        _policiesCount = MIN(policies.count, 4);
+        _managedByOwner = NO;
+        [policies enumerateObjectsUsingBlock:^(NSNumber * policy, NSUInteger idx, BOOL * stop) {
+            if (idx < _policiesCount) {
+                _policies[idx].numericValue = [policy unsignedIntegerValue];
+                if (_policies[idx].policy.policyType == RPT_Manual) {
+                    _managedByOwner = YES;
+                }
+            }
+        }];
+    }
+    return self;
+}
+
+- (BOOL) setUsed
+{
+    _usageCount++;
+    _lastUseDate = [NSDate date];
+    return [self isStillValid];
+}
+
+
+/// Evaluate whether time interval between now and reference date is greater or equal than time interval in release policy.
+/// - Parameters:
+///   - refDate: Reference date.
+///   - rp: Pointer to release policy structure.
+static inline BOOL _IsExpired(NSDate * refDate, ReleasePolicy rp)
+{
+    return (NSInteger)(-[refDate timeIntervalSinceNow] * 1000.0) >= rp.policy.policyParam;
+}
+
+- (BOOL) isStillValid
+{
+    // In case that object is manually managed, then don't iterate over the policies.
+    if (_managedByOwner) {
+        return YES;
+    }
+    for (NSUInteger idx = 0; idx < _policiesCount; ++idx) {
+        switch (_policies[idx].policy.policyType) {
+            case RPT_AfterUse:
+                if (_usageCount >= _policies[idx].policy.policyParam) {
+                    return NO;
+                }
+                break;
+            case RPT_Expire:
+                if (_IsExpired(_createDate, _policies[idx])) {
+                    return NO;
+                }
+                break;
+            case RPT_KeepAlive:
+                if (_IsExpired(_lastUseDate, _policies[idx])) {
+                    return NO;
+                }
+                break;
+            default:
+                break;
+        }
+    }
+    return YES;
+}
+
+- (NSDictionary*) debugDump
+{
+#if DEBUG
+    // Iterate over policies
+    __block BOOL printLastUseDate = NO;
+    __block BOOL printUsageCount = NO;
+    NSArray * policies;
+    if (_managedByOwner) {
+        policies = @[ @"MANUAL" ];
+    } else {
+        NSMutableArray * p = [NSMutableArray array];
+        for (NSUInteger idx = 0; idx < _policiesCount; ++idx) {
+            switch (_policies[idx].policy.policyType) {
+                case RPT_AfterUse:
+                    [p addObject:[NSString stringWithFormat:@"AFTER_USE(%@/%@)", @(_usageCount), @(_policies[idx].policy.policyParam)]];
+                    printUsageCount = YES;
+                    break;
+                case RPT_KeepAlive:
+                    [p addObject:[NSString stringWithFormat:@"KEEP_ALIVE(%@)", @(_policies[idx].policy.policyParam)]];
+                    printLastUseDate = YES;
+                    break;
+                case RPT_Expire:
+                    [p addObject:[NSString stringWithFormat:@"EXPIRE(%@)", @(_policies[idx].policy.policyParam)]];
+                    break;
+                case RPT_Manual:
+                    break;
+            }
+        }
+        policies = p;
+    }
+    return @{
+        @"id": _key,
+        @"class": NSStringFromClass([_object class]),
+        @"tag": _tag ? _tag : [NSNull null],
+        @"createDate": @([_createDate timeIntervalSince1970]),
+        @"lastUseDate": printLastUseDate ? @([_lastUseDate timeIntervalSince1970]) : [NSNull null],
+        @"usageCount": printUsageCount ? @(_usageCount) : [NSNull null],
+        @"policies": policies,
+        @"isValid": @([self isStillValid])
+    };
+#else
+    return @{};
+#endif // DEBUG
+}
+
+@end

--- a/ios/PowerAuth/Utilities.h
+++ b/ios/PowerAuth/Utilities.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#ifdef __cplusplus
+    // C++
+    #define PA_EXTERN_C                extern "C"
+    #define PA_EXTERN_C_BEGIN          extern "C" {
+    #define PA_EXTERN_C_END            }
+#else
+    // C
+    #define PA_EXTERN_C                extern
+    #define PA_EXTERN_C_BEGIN
+    #define PA_EXTERN_C_END
+#endif
+
+/**
+ Macro to cast object to desired class, or return nil if object is different kind of class.
+ */
+#define CAST_TO(object, requiredClass) ((requiredClass*)(CastObjectTo(object, [requiredClass class])))
+
+/// Cast object to desired class, or return nil if object is different kind of class.
+/// @param instance Object to cast.
+/// @param desiredClass Required class
+/// @return The provided instance or nil if object is not kind of required class.
+PA_EXTERN_C id CastObjectTo(id instance, Class desiredClass);
+
+/// Patch nulls in object to undefined (e.g. remove keys with nulls)
+/// @param object Object to patch.
+/// @return Patched object that doesn't contain `NSNull` instances.
+PA_EXTERN_C id PatchNull(id object);
+
+/// Extract NSString value from dictionary containing encoded JS object.
+/// @param dict Dictionary containing JS object.
+/// @param key Key for value to extract from the dictionary.
+/// @return String extracted from the dictionary.
+PA_EXTERN_C NSString * GetNSStringValueFromDict(NSDictionary * dict, NSString * key);
+
+/// Extract NSData value from dictionary containing encoded JS object. The dictionary must contain
+/// Base64 encoded string for the provided key.
+/// @param dict Dictionary containing JS object.
+/// @param key Key for value to extract from the dictionary.
+/// @return NSData extracted from the dictionary.
+PA_EXTERN_C NSData * GetNSDataValueFromDict(NSDictionary * dict, NSString * key);

--- a/ios/PowerAuth/Utilities.m
+++ b/ios/PowerAuth/Utilities.m
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "Utilities.h"
+#import <React/RCTConvert.h>
+
+id CastObjectTo(id instance, Class desiredClass) {
+    if ([instance isKindOfClass:desiredClass]) {
+        return instance;
+    }
+    return nil;
+}
+
+id PatchNull(id object) {
+    if (object == [NSNull null]) {
+        return nil;
+    }
+    if ([object isKindOfClass:[NSDictionary class]]) {
+        // Key-value dictionary
+        NSMutableDictionary * newObject = [object mutableCopy];
+        [(NSDictionary*)object enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL * stop) {
+            newObject[key] = PatchNull(value);
+        }];
+        return newObject;
+    }
+    return object;
+}
+
+/// Extract NSString value from dictionary containing encoded JS object.
+/// @param dict Dictionary containing JS object.
+/// @param key Key for value to extract from the dictionary.
+/// @return String extracted from the dictionary.
+NSString * GetNSStringValueFromDict(NSDictionary * dict, NSString * key)
+{
+    id value = dict[key];
+    if (value == nil || value == [NSNull null]) {
+        return nil;
+    }
+    return [RCTConvert NSString:value];
+}
+
+/// Extract NSData value from dictionary containing encoded JS object. The dictionary must contain
+/// Base64 encoded string for the provided key.
+/// @param dict Dictionary containing JS object.
+/// @param key Key for value to extract from the dictionary.
+/// @return NSData extracted from the dictionary.
+NSData * GetNSDataValueFromDict(NSDictionary * dict, NSString * key)
+{
+    NSString * encodedData = GetNSStringValueFromDict(dict, key);
+    if (encodedData) {
+        return [[NSData alloc] initWithBase64EncodedString:encodedData options:NSDataBase64DecodingIgnoreUnknownCharacters];
+    }
+    return nil;
+}

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
     "lib/*.*",
     "lib/internal/*.js",
     "lib/model/*.*",
+    "lib/debug/*.*",
     "ios/PowerAuth.xcodeproj/project.pbxproj",
-    "ios/PowerAuth/PowerAuth.m",
-    "ios/PowerAuth/PowerAuth.h",
+    "ios/PowerAuth/*.m",
+    "ios/PowerAuth/*.h",
     "react-native-powerauth-mobile-sdk.podspec"
   ],
   "scripts": {

--- a/scripts/build-library.sh
+++ b/scripts/build-library.sh
@@ -25,10 +25,26 @@ npx pod-install
 
 pushd ios
 
+echo '------------------------------------------------------------'
+echo 'Compiling iOS Release'
+echo '------------------------------------------------------------'
+
 xcrun xcodebuild \
     -workspace "PowerAuth.xcworkspace" \
     -scheme "PowerAuth" \
     -configuration "Release" \
+    -sdk "iphonesimulator" \
+    -arch x86_64 \
+    build
+
+echo '------------------------------------------------------------'
+echo 'Compiling iOS Debug'
+echo '------------------------------------------------------------'
+
+xcrun xcodebuild \
+    -workspace "PowerAuth.xcworkspace" \
+    -scheme "PowerAuth" \
+    -configuration "Debug" \
     -sdk "iphonesimulator" \
     -arch x86_64 \
     build

--- a/src/debug/NativeObjectRegister.ts
+++ b/src/debug/NativeObjectRegister.ts
@@ -1,0 +1,86 @@
+//
+// Copyright 2022 Wultra s.r.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { NativeModules } from "react-native";
+
+/**
+ * WARNING
+ *
+ * This file contains declaration of internal types that helps with
+ * debugging and testing the library. The library must be compiled
+ * with DEBUG build configuration to expose such functionality.
+ */
+
+/**
+ * Information about underlying native object.
+ */
+export interface NativeObjectInfo {
+    id: string              // object's identifier
+    class: string           // obejct's class
+    tag?: string            // object's tag
+    isValid: boolean        // whether object is still valid
+    policies: string[]      // list of policies
+    createDate: number      // object's creation date
+    lastUseDate?: number    // object's last usage date
+    usageCount?: number     // obejct's usage counter
+}
+
+/**
+ * Command type.
+ */
+export type NativeObjectCmd = 'create' | 'release' | 'releaseAll' | 'use' | 'find' | 'setPeriod'
+/**
+ * Native object types.
+ */
+export type NativeObjectType = 'data' | 'secure-data'
+/**
+ * Data accepted in debugCommand() function. 
+ */
+export interface NativeObjectCmdData {
+    objectId?: string               // object id, accepted in 'release', 'use', 'find'
+    objectTag?: string              // object tag, accepted in 'create', 'releaseAll'
+    objectType?: NativeObjectType   // object type accepted in 'create', 'release', 'use', 'find'
+    releasePolicy?: string[]        // use 'manual', 'after_use N', 'keep_alive T', 'expore T', accepted in 'create'
+    cleanupPeriod?: number          // cleanup period in milliseconds <100, 60000>, accepted in 'setPeriod'
+}
+/**
+ * Result returned from debugCommand()  
+ */
+export type NativeObjectCmdResult = boolean | string | undefined
+
+/**
+ * Debug interface exposed by native object register.
+ */
+export interface NativeObjectRegisterIfc {
+    /**
+     * Dump content of internal native object register. The function is implemented in DEBUG build of the library.
+     * @param instanceId If provided, then returns only objects associated to PowerAuth instance identifier.
+     * @returns Array with `NativeObjectInfo`
+     */
+    debugDump(instanceId: string | undefined): Promise<Array<NativeObjectInfo>>
+    /**
+     * Manipulate with object register. The function is implemented in DEBUG build of the library.
+     * @param command Command to execute.
+     * @param data Command data.
+     * @returns Command result.
+     */
+    debugCommand(command: NativeObjectCmd, data: NativeObjectCmdData): Promise<NativeObjectCmdResult>
+}
+
+/**
+ * Instance of native object register.
+ */
+export const NativeObjectRegister = NativeModules.PowerAuthObjectRegister as NativeObjectRegisterIfc

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,6 @@
 export * from './PowerAuth';
 export * from './PowerAuthActivationCodeUtil';
 export * from './PowerAuthTokenStore';
-export * from './PowerAuthDebug';
 
 // Model objects
 
@@ -37,3 +36,8 @@ export * from './model/PowerAuthCreateActivationResult';
 export * from './model/PowerAuthError';
 export * from './model/PowerAuthKeychainConfiguration';
 export * from './model/PowerAuthRecoveryActivationData';
+
+// Debug features
+
+export * from './debug/PowerAuthDebug';
+export * from './debug/NativeObjectRegister';

--- a/src/internal/AuthResolver.ts
+++ b/src/internal/AuthResolver.ts
@@ -40,7 +40,7 @@ export class AuthResolver {
      * @returns configured authorization object
      */
     async resolve(authentication: PowerAuthAuthentication, makeReusable: boolean = false): Promise<PowerAuthAuthentication> {
-        const obj: ReusablePowerAuthAuthentication = { ...authentication };
+        const obj: ReusablePowerAuthAuthentication = { ...authentication }
         // Test whether previously fetched biometryKeyId is invalid. Reset biometry key's identifier
         // if underlying data object is no longer valid.
         if (obj.biometryKeyId && !NativeObject.isValidNativeObject(obj.biometryKeyId)) {
@@ -52,17 +52,15 @@ export class AuthResolver {
             (Platform.OS == 'ios' && makeReusable)) {
             try {
                 // Android requires to always provide title and message
-                const title   = authentication.biometryTitle ?? "??"
-                const message = authentication.biometryMessage ?? "??"
-                const keepAlive = 10000 // 10 seconds from last internal data use
-                // Acquire i
-                obj.biometryKeyId = (await NativeWrapper.thisCall("authenticateWithBiometry", this.instanceId, title, message, keepAlive)) as string;
+                const title   = authentication.biometryTitle ?? '??'
+                const message = authentication.biometryMessage ?? '??'
+                // Acquire biometry key. The function returns ID to underlying data object with a limited validity.
+                obj.biometryKeyId = (await NativeWrapper.thisCall('authenticateWithBiometry', this.instanceId, title, message, makeReusable)) as string;
                 return obj;
             } catch (e) {
                 throw NativeWrapper.processException(e)
             }
         }
-        
         // no need for processing, just return original object
         return authentication;
     }

--- a/src/internal/AuthResolver.ts
+++ b/src/internal/AuthResolver.ts
@@ -15,8 +15,9 @@
 //
 
 import { Platform } from 'react-native';
-import { PowerAuthAuthentication } from '../index';
+import { PowerAuthAuthentication, PowerAuthError, PowerAuthErrorCode } from '../index';
 import { NativeWrapper } from './NativeWrapper';
+import { NativeObject } from './NativeObject';
 
 /**
  * The `AuthResolver` helper class hides internal dependencies when PowerAuthAuthentication needs to be
@@ -35,15 +36,27 @@ export class AuthResolver {
      * 
      * @param authentication authentication configuration
      * @param makeReusable if the object should be forced to be reusable
+     * @param recoveringFromError if true, then this is call
      * @returns configured authorization object
      */
     async resolve(authentication: PowerAuthAuthentication, makeReusable: boolean = false): Promise<PowerAuthAuthentication> {
         const obj: ReusablePowerAuthAuthentication = { ...authentication };
+        // Test whether previously fetched biometryKeyId is invalid. Reset biometry key's identifier
+        // if underlying data object is no longer valid.
+        if (obj.biometryKeyId && !NativeObject.isValidNativeObject(obj.biometryKeyId)) {
+            obj.biometryKeyId = undefined
+        }
         // On android, we need to fetch the key for every biometric authentication.
         // If the key is already set, use it (we're processing reusable biometric authentication)
-        if ((Platform.OS == 'android' && authentication.useBiometry && (obj.biometryKey === undefined || makeReusable)) || (Platform.OS == 'ios' && makeReusable)) {
+        if ((Platform.OS == 'android' && authentication.useBiometry && (!obj.biometryKeyId || makeReusable)) ||
+            (Platform.OS == 'ios' && makeReusable)) {
             try {
-                obj.biometryKey = (await NativeWrapper.thisCall("authenticateWithBiometry", this.instanceId, authentication.biometryTitle ?? "??", authentication.biometryMessage ?? "??")) as string;
+                // Android requires to always provide title and message
+                const title   = authentication.biometryTitle ?? "??"
+                const message = authentication.biometryMessage ?? "??"
+                const keepAlive = 10000 // 10 seconds from last internal data use
+                // Acquire i
+                obj.biometryKeyId = (await NativeWrapper.thisCall("authenticateWithBiometry", this.instanceId, title, message, keepAlive)) as string;
                 return obj;
             } catch (e) {
                 throw NativeWrapper.processException(e)
@@ -59,5 +72,8 @@ export class AuthResolver {
  * Extended PowerAuthAuthentication object containing a biometry key.
  */
 class ReusablePowerAuthAuthentication extends PowerAuthAuthentication {
-    biometryKey?: string
+    /**
+     * Contains identifier for data allocated in native code.
+     */
+    biometryKeyId?: string
 }

--- a/src/internal/NativeObject.ts
+++ b/src/internal/NativeObject.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright 2020 Wultra s.r.o.
+/*
+ * Copyright 2021 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,17 @@
  * limitations under the License.
  */
 
-#import <React/RCTBridgeModule.h>
-#import <React/RCTInitializing.h>
-#import "PowerAuthObjectRegister.h"
+import { NativeModules } from "react-native"
 
-@interface PowerAuth: NSObject<RCTBridgeModule, RCTInitializing>
+/**
+ * Low level interface provided by native PowerAuthObjectRegister.
+ */
+export interface NativeObject {
+    /**
+     * Test whether underlying native object register still contains object with given ID.
+     * @param objectId Object identifier to test.
+     */
+    isValidNativeObject(objectId: string): Promise<boolean>
+}
 
-@end
+export const NativeObject = NativeModules.PowerAuthObjectRegister as NativeObject

--- a/src/internal/NativeWrapper.ts
+++ b/src/internal/NativeWrapper.ts
@@ -16,7 +16,7 @@
 
 import { NativeModules, Platform } from 'react-native';
 import { PowerAuthError } from '../model/PowerAuthError';
-import { PowerAuthDebug } from '../PowerAuthDebug';
+import { PowerAuthDebug } from '../debug/PowerAuthDebug';
 
 interface StaticCallTrampoline {
     call<T>(name: string, args: any[]): Promise<T>

--- a/src/model/PowerAuthError.ts
+++ b/src/model/PowerAuthError.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { PowerAuthDebug } from "../PowerAuthDebug";
+import { PowerAuthDebug } from "../debug/PowerAuthDebug";
 
 /**
  * PowerAuthError is a wrapper error that is thrown by every API in this module.
@@ -169,4 +169,10 @@ export enum PowerAuthErrorCode {
 
     /** Failed with unexpected error. */
     UNKNOWN_ERROR = "UNKNOWN_ERROR",
+
+    /** 
+     * Underlying native object is no longer valid. This may happen in situations
+     * when you're using 
+     */
+    INVALID_NATIVE_OBJECT = "INVALID_NATIVE_OBJECT",
 }

--- a/testapp/_tests/AllTests.ts
+++ b/testapp/_tests/AllTests.ts
@@ -23,6 +23,7 @@ import { PowerAuth_ActivationTests } from "./PowerAuth_Activation.test";
 import { PowerAuth_RecoveryTests } from "./PowerAuth_Recovery.test";
 import { PowerAuth_PasswordTests } from "./PowerAuth_Password.test";
 import { PowerAuth_BiometryTests } from "./PowerAuth_Biometry.test";
+import { PowerAuth_BiometryInteractiveTests } from "./PowerAuth_BiometryInteractive.test";
 import { PowerAuth_SignatureTests } from "./PowerAuth_Signature.test";
 import { PowerAuth_TokenTests } from "./PowerAuth_Token.test";
 import { PowerAuth_EncryptionTests } from "./PowerAuth_Encryption.test";
@@ -44,12 +45,18 @@ export function getLibraryTests(): TestSuite[] {
         new PowerAuthActivationTests(),
         new PowerAuthActivationCodeUtilTests(),
         new NativeObjectRegisterTests(),
-    ];
+    ]
+}
+
+export function getInteractiveLibraryTests(): TestSuite[] {
+    return [
+        new PowerAuth_BiometryInteractiveTests()
+    ]
 }
 
 export function getTestbedTests(): TestSuite[] {
     return [
         new TestRunnerTests(),
         new TestSuiteTests()
-    ];
+    ]
 }

--- a/testapp/_tests/AllTests.ts
+++ b/testapp/_tests/AllTests.ts
@@ -28,6 +28,7 @@ import { PowerAuth_TokenTests } from "./PowerAuth_Token.test";
 import { PowerAuth_EncryptionTests } from "./PowerAuth_Encryption.test";
 import { PowerAuth_ConfigureTests } from "./PowerAuth_Configure.test";
 import { PowerAuth_Example } from "./PowerAuth_Example";
+import { NativeObjectRegisterTests } from "./NativeObjectRegister.test";
 
 export function getLibraryTests(): TestSuite[] {
     return [
@@ -42,6 +43,7 @@ export function getLibraryTests(): TestSuite[] {
         new PowerAuth_EncryptionTests(),
         new PowerAuthActivationTests(),
         new PowerAuthActivationCodeUtilTests(),
+        new NativeObjectRegisterTests(),
     ];
 }
 

--- a/testapp/_tests/NativeObjectRegister.test.ts
+++ b/testapp/_tests/NativeObjectRegister.test.ts
@@ -1,0 +1,254 @@
+//
+// Copyright 2022 Wultra s.r.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { expect } from "../src/testbed";
+import { Platform } from "react-native";
+import { PowerAuthDebug, NativeObjectRegister, NativeObjectType, NativeObjectCmdData, NativeObjectCmdResult } from "react-native-powerauth-mobile-sdk";
+import { TestWithActivation } from "./helpers/TestWithActivation";
+
+interface ObjectsCount {
+    valid: number
+    invalid: number
+}
+
+/**
+ * The Register class extends `NativeObjectRegister` functionality for this test suite purposes.
+ * 
+ * ### Warning
+ * 
+ * > You suppose do not replicate such functionality in your application's code, because it will not
+ * > work in the release build.
+ */
+class Register {
+    static async findObject(objectId: string, type: NativeObjectType): Promise<boolean> {
+        const r = await NativeObjectRegister.debugCommand('find', { objectId: objectId, objectType: type })
+        if (typeof r === 'boolean') {
+            return r
+        } else {
+            throw new Error('Unexpected result')
+        }
+    }
+
+    static async useObject(objectId: string, type: NativeObjectType): Promise<boolean> {
+        const r = await NativeObjectRegister.debugCommand('use', { objectId: objectId, objectType: type })
+        if (typeof r === 'boolean') {
+            return r
+        } else {
+            throw new Error('Unexpected result')
+        }
+    }
+
+    static async removeObject(objectId: string, type: NativeObjectType): Promise<boolean> {
+        const r = await NativeObjectRegister.debugCommand('release', { objectId: objectId, objectType: type })
+        if (typeof r === 'boolean') {
+            return r
+        } else {
+            throw new Error('Unexpected result')
+        }
+    }
+
+    static async createObject(data: NativeObjectCmdData): Promise<string> {
+        const r = await NativeObjectRegister.debugCommand('create', data)
+        if (typeof r === 'string') {
+            return r
+        } else {
+            throw new Error('Unexpected result')
+        }
+    }
+
+    static setCleanupPeriod(periodInMs: number): Promise<NativeObjectCmdResult> {
+        return NativeObjectRegister.debugCommand('setPeriod', { cleanupPeriod: periodInMs })
+    }
+
+    static async countObjects(tag: string): Promise<ObjectsCount> {
+        const r = await NativeObjectRegister.debugDump(tag)
+        return { 
+            valid:   r.reduce((prev, item) => prev + (item.isValid ? 1 : 0), 0), 
+            invalid: r.reduce((prev, item) => prev + (item.isValid ? 0 : 1), 0)
+        }
+    }
+}
+
+export class NativeObjectRegisterTests extends TestWithActivation {
+
+    shouldCreateActivationBeforeTest(): boolean {
+        return false // this test doesn't require activation
+    }
+
+    async beforeAll() {
+        await super.beforeAll()
+        if (Platform.OS === 'android') {
+            this.reportSkip('Not available yet for Android')
+        }
+        // Set very short cleanup period
+        await Register.setCleanupPeriod(100)
+    }
+
+    async afterAll() {
+        await super.afterAll()
+        // Set back the default period
+        await Register.setCleanupPeriod(0)
+    }
+
+    getRandomTag(): string {
+        return 'tag_' + (Math.random() + 1).toString(36).substring(7)
+    }
+
+    async testDumpingRegisteredObjects() {
+
+        const tag = this.getRandomTag()
+        this.reportInfo(`Using tag '${tag}'`)
+
+        const dataId1 = await Register.createObject({ objectType: 'data', objectTag: tag, releasePolicy: ['expire 400'] })
+        const dataId2 = await Register.createObject({ objectType: 'secure-data', objectTag: tag, releasePolicy: ['keepAlive 200'] })
+        const dataId3 = await Register.createObject({ objectType: 'secure-data', objectTag: tag, releasePolicy: ['afterUse 2'] })
+
+        expect(await Register.findObject(dataId1, 'data')).toBe(true)
+        expect(await Register.findObject(dataId2, 'secure-data')).toBe(true)
+        expect(await Register.findObject(dataId3, 'secure-data')).toBe(true)
+
+        await Register.useObject(dataId3, 'secure-data')
+        expect(await Register.findObject(dataId3, 'secure-data')).toBe(true)
+        await Register.useObject(dataId3, 'secure-data')
+        expect(await Register.findObject(dataId3, 'secure-data')).toBe(false)
+
+        await PowerAuthDebug.dumpNativeObjects(tag)
+    }
+
+    async testObjectsExpiration() {
+        const tag = this.getRandomTag()
+        this.debugInfo(`Using tag '${tag}'`)
+
+        const dataId1 = await Register.createObject({ objectType: 'data', objectTag: tag, releasePolicy: ['expire 400', 'afterUse 1'] })
+        const dataId2 = await Register.createObject({ objectType: 'secure-data', objectTag: tag, releasePolicy: ['expire 200', 'keepAlive 400'] })
+        
+        this.debugInfo(`Using IDs '${dataId1}', '${dataId2}'`)
+
+        expect(await Register.findObject(dataId1, 'data')).toBe(true)
+        expect(await Register.findObject(dataId2, 'secure-data')).toBe(true)
+        expect((await Register.countObjects(tag)).valid).toBe(2)
+
+        await this.sleep(200)
+
+        expect(await Register.findObject(dataId1, 'data')).toBe(true)
+        expect(await Register.findObject(dataId2, 'secure-data')).toBe(false)
+        expect((await Register.countObjects(tag)).valid).toBe(1)
+
+        await this.sleep(200)
+
+        expect(await Register.findObject(dataId1, 'data')).toBe(false)
+        expect(await Register.findObject(dataId2, 'secure-data')).toBe(false)
+        expect((await Register.countObjects(tag)).valid).toBe(0)
+    }
+
+    async testUsageCount() {
+        const tag = this.getRandomTag()
+        this.debugInfo(`Using tag '${tag}'`)
+
+        const dataId1 = await Register.createObject({ objectType: 'data', objectTag: tag, releasePolicy: ['afterUse 1'] })
+        const dataId2 = await Register.createObject({ objectType: 'data', objectTag: tag, releasePolicy: ['expire 300', 'afterUse 2'] })
+        const dataId3 = await Register.createObject({ objectType: 'data', objectTag: tag, releasePolicy: ['keepAlive 100', 'afterUse 4'] })
+        const dataId4 = await Register.createObject({ objectType: 'data', objectTag: tag, releasePolicy: ['keepAlive 100', 'afterUse 4'] })
+        
+        this.debugInfo(`Using IDs '${dataId1}', '${dataId2}', '${dataId3}', '${dataId4}'`)
+
+        // Initial expectation
+        expect(await Register.findObject(dataId1, 'data')).toBe(true)
+        expect(await Register.findObject(dataId2, 'data')).toBe(true)
+        expect(await Register.findObject(dataId3, 'data')).toBe(true)
+        expect(await Register.findObject(dataId4, 'data')).toBe(true)
+        expect((await Register.countObjects(tag)).valid).toBe(4)
+
+        await this.sleep(50)
+        // After 50ms everything should be still valid
+        expect((await Register.countObjects(tag)).valid).toBe(4)
+
+        // use dataId4, this will extend its lifetime
+        expect(await Register.useObject(dataId4, 'data')).toBe(true)
+
+        await this.sleep(50)
+        // After next 50ms, dataId3 will be removed
+        expect(await Register.findObject(dataId1, 'data')).toBe(true)
+        expect(await Register.findObject(dataId2, 'data')).toBe(true)
+        expect(await Register.findObject(dataId3, 'data')).toBe(false)
+        expect(await Register.findObject(dataId4, 'data')).toBe(true)
+
+        // Now use dataId2 for 1st time
+        expect(await Register.useObject(dataId2, 'data')).toBe(true)
+        
+        expect(await Register.findObject(dataId1, 'data')).toBe(true)
+        expect(await Register.findObject(dataId2, 'data')).toBe(true)
+        expect(await Register.findObject(dataId3, 'data')).toBe(false)
+        expect(await Register.findObject(dataId4, 'data')).toBe(true)
+
+        await this.sleep(50)
+        // Now use dataId2 for 2nd time, it should be released now
+        // Also dataId4 is now released
+        expect(await Register.useObject(dataId2, 'data')).toBe(true)
+        
+        expect(await Register.findObject(dataId1, 'data')).toBe(true)
+        expect(await Register.findObject(dataId2, 'data')).toBe(false)
+        expect(await Register.findObject(dataId3, 'data')).toBe(false)
+        expect(await Register.findObject(dataId4, 'data')).toBe(false)
+
+        // And finally, use dataId4, to release it
+
+        expect(await Register.useObject(dataId1, 'data')).toBe(true)
+
+        expect(await Register.findObject(dataId1, 'data')).toBe(false)
+        expect(await Register.findObject(dataId2, 'data')).toBe(false)
+        expect(await Register.findObject(dataId3, 'data')).toBe(false)
+        expect(await Register.findObject(dataId4, 'data')).toBe(false)
+        expect((await Register.countObjects(tag)).valid).toBe(0)
+    }
+
+    async testManualRelease() {
+        const tag = this.getRandomTag()
+        this.debugInfo(`Using tag '${tag}'`)
+
+        const dataId1 = await Register.createObject({ objectType: 'data', objectTag: tag, releasePolicy: ['afterUse 1', 'manual'] })
+        const dataId2 = await Register.createObject({ objectType: 'data', objectTag: tag, releasePolicy: ['manual', 'expire 100', 'afterUse 2'] })
+        const dataId3 = await Register.createObject({ objectType: 'data', objectTag: tag, releasePolicy: ['keepAlive 100', 'afterUse 4', 'manual'] })
+        const dataId4 = await Register.createObject({ objectType: 'data', objectTag: tag, releasePolicy: ['manual'] })
+
+        this.debugInfo(`Using IDs '${dataId1}', '${dataId2}', '${dataId3}', '${dataId4}'`)
+
+        // All manual objects must be in the register for the whole time 
+        expect(await Register.findObject(dataId1, 'data')).toBe(true)
+        expect(await Register.findObject(dataId2, 'data')).toBe(true)
+        expect(await Register.findObject(dataId3, 'data')).toBe(true)
+        expect(await Register.findObject(dataId4, 'data')).toBe(true)
+        expect((await Register.countObjects(tag)).valid).toBe(4)
+
+        expect(await Register.useObject(dataId1, 'data')).toBe(true)
+        expect(await Register.findObject(dataId1, 'data')).toBe(true)
+
+        this.sleep(110)
+
+        expect(await Register.findObject(dataId1, 'data')).toBe(true)
+        expect(await Register.findObject(dataId2, 'data')).toBe(true)
+        expect(await Register.findObject(dataId3, 'data')).toBe(true)
+        expect(await Register.findObject(dataId4, 'data')).toBe(true)
+
+        // Now remove objects manually
+        expect(await Register.removeObject(dataId1, 'data')).toBe(true)
+        expect(await Register.removeObject(dataId2, 'data')).toBe(true)
+        expect(await Register.removeObject(dataId3, 'data')).toBe(true)
+        expect(await Register.removeObject(dataId4, 'data')).toBe(true)
+
+        expect((await Register.countObjects(tag)).valid).toBe(0)
+    }
+}

--- a/testapp/_tests/PowerAuth_BiometryInteractive.test.ts
+++ b/testapp/_tests/PowerAuth_BiometryInteractive.test.ts
@@ -1,0 +1,88 @@
+//
+// Copyright 2022 Wultra s.r.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { TestWithActivation } from "./helpers/TestWithActivation";
+import { CustomActivationHelperPrepareData } from "./helpers/RNActivationHelper";
+import { expect } from "../src/testbed";
+import { PowerAuthBiometryConfiguration, PowerAuthBiometryStatus, PowerAuthErrorCode } from "react-native-powerauth-mobile-sdk";
+
+export class PowerAuth_BiometryInteractiveTests extends TestWithActivation {
+
+    /**
+     * Construct this test suite as interactive
+     * @param suiteName Optional test stuite name
+     */
+    constructor(suiteName: string | undefined = undefined) {
+        super(suiteName, true)
+    }
+
+    customPrepareData(): CustomActivationHelperPrepareData {
+        // Use config that allows create activation with biometry key with no user's interaction
+        const config = new PowerAuthBiometryConfiguration()
+        config.authenticateOnBiometricKeySetup = false
+        return {
+            useConfigObjects: true,
+            useBiometry: true,
+            biometryConfig: config,
+            password: this.credentials.validPassword
+        }
+    }
+
+    async beforeEach(): Promise<void> {
+        await super.beforeEach()
+        let biometryInfo = await this.sdk.getBiometryInfo()
+        if (biometryInfo.canAuthenticate !== PowerAuthBiometryStatus.OK) {
+            this.reportSkip(`Biometric status is ${biometryInfo.canAuthenticate}`)
+        }
+    }
+
+    async testGroupedBiometricAuthentication() {
+        expect(await this.sdk.hasBiometryFactor()).toBe(true)
+        await this.showPrompt('Please authenticate with biometry. The biometric dialog will be displayed only for once.')
+        await this.sdk.groupedBiometricAuthentication(this.credentials.biometry, async reusableAuth => {
+            // Calculate signature 
+            let data = '{}'
+            let uriId = '/some/uriId'
+            let header = await this.sdk.requestSignature(reusableAuth, 'POST', uriId, data)
+            // Verify signature
+            let result = await this.helper.signatureHelper.verifyOnlineSignature('POST', uriId, data, header.value)
+            expect(result).toBe(true)
+            
+            // Calculate yet another signature and verify
+            data = '{"value":true}'
+            uriId = '/another/uriId'
+
+            header = await this.sdk.requestSignature(reusableAuth, 'POST', uriId, data)
+            result = await this.helper.signatureHelper.verifyOnlineSignature('POST', uriId, data, header.value)
+            expect(result).toBe(true)
+        })
+    }
+
+    async testRemoveActivationWithBiometry() {
+        expect(await this.sdk.hasBiometryFactor()).toBe(true)
+        await this.showPrompt('Please authenticate with biometry')
+        await this.sdk.removeActivationWithAuthentication(this.credentials.biometry)
+    }
+    
+
+    // On iOS emulator you cannot cancel biometry
+
+    // async testCancelBiometry() {
+    //     expect(await this.sdk.hasBiometryFactor()).toBe(true)
+    //     await this.showPrompt('Please cancel authentication dialog')    
+    //     await expect(async () => this.sdk.requestSignature(this.credentials.biometry, 'POST', '/some/uriId', '{}')).toThrow({ errorCode: PowerAuthErrorCode.BIOMETRY_CANCEL })
+    // }
+}

--- a/testapp/_tests/PowerAuth_BiometryInteractive.test.ts
+++ b/testapp/_tests/PowerAuth_BiometryInteractive.test.ts
@@ -16,7 +16,7 @@
 
 import { TestWithActivation } from "./helpers/TestWithActivation";
 import { CustomActivationHelperPrepareData } from "./helpers/RNActivationHelper";
-import { expect } from "../src/testbed";
+import { expect, UserPromptDuration } from "../src/testbed";
 import { PowerAuthBiometryConfiguration, PowerAuthBiometryStatus, PowerAuthErrorCode } from "react-native-powerauth-mobile-sdk";
 
 export class PowerAuth_BiometryInteractiveTests extends TestWithActivation {
@@ -51,8 +51,10 @@ export class PowerAuth_BiometryInteractiveTests extends TestWithActivation {
 
     async testGroupedBiometricAuthentication() {
         expect(await this.sdk.hasBiometryFactor()).toBe(true)
-        await this.showPrompt('Please authenticate with biometry. The biometric dialog will be displayed only for once.')
+        await this.showPrompt('Please authenticate with biometry.')
         await this.sdk.groupedBiometricAuthentication(this.credentials.biometry, async reusableAuth => {
+            //
+            await this.showPrompt('Biometric dialog should not be displayed.', UserPromptDuration.QUICK)
             // Calculate signature 
             let data = '{}'
             let uriId = '/some/uriId'
@@ -60,7 +62,8 @@ export class PowerAuth_BiometryInteractiveTests extends TestWithActivation {
             // Verify signature
             let result = await this.helper.signatureHelper.verifyOnlineSignature('POST', uriId, data, header.value)
             expect(result).toBe(true)
-            
+            //
+            await this.showPrompt('Biometric dialog should not be displayed.', UserPromptDuration.QUICK)
             // Calculate yet another signature and verify
             data = '{"value":true}'
             uriId = '/another/uriId'
@@ -73,12 +76,12 @@ export class PowerAuth_BiometryInteractiveTests extends TestWithActivation {
 
     async testRemoveActivationWithBiometry() {
         expect(await this.sdk.hasBiometryFactor()).toBe(true)
-        await this.showPrompt('Please authenticate with biometry')
+        await this.showPrompt('Authenticate to remove activation')
         await this.sdk.removeActivationWithAuthentication(this.credentials.biometry)
     }
     
 
-    // On iOS emulator you cannot cancel biometry
+    // TODO: On iOS emulator you cannot cancel biometry
 
     // async testCancelBiometry() {
     //     expect(await this.sdk.hasBiometryFactor()).toBe(true)

--- a/testapp/_tests/testbed/CustomInteraction.ts
+++ b/testapp/_tests/testbed/CustomInteraction.ts
@@ -14,11 +14,11 @@
 // limitations under the License.
 //
 
-import { TestContext, UserInteraction, TestPromptDuration } from "../../src/testbed";
+import { TestContext, UserInteraction, UserPromptDuration } from "../../src/testbed";
 
 export interface PromptWithDuration {
     prompt: string
-    duration: TestPromptDuration
+    duration: UserPromptDuration
 }
 
 export class CustomInteraction implements UserInteraction {
@@ -28,7 +28,7 @@ export class CustomInteraction implements UserInteraction {
         this.promptList = []
     }
 
-    async showPrompt(context: TestContext, message: string, duration: TestPromptDuration): Promise<void> {
+    async showPrompt(context: TestContext, message: string, duration: UserPromptDuration): Promise<void> {
         this.promptList.push({prompt: message, duration: duration})
     }
 }

--- a/testapp/ios/testapp/Info.plist
+++ b/testapp/ios/testapp/Info.plist
@@ -51,5 +51,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Using FaceID for the testing purposes</string>
 </dict>
 </plist>

--- a/testapp/src/App.tsx
+++ b/testapp/src/App.tsx
@@ -24,7 +24,7 @@ import {
 } from 'react-native'
 import { getInteractiveLibraryTests, getLibraryTests, getTestbedTests } from '../_tests/AllTests'
 import { getTestConfig } from './Config'
-import { TestContext, TestPromptDuration, UserInteraction } from './testbed'
+import { TestContext, UserPromptDuration, UserInteraction } from './testbed'
 import { TestLog } from './testbed/TestLog'
 import { TestMonitorGroup } from './testbed/TestMonitor'
 import { TestRunner } from './testbed/TestRunner'
@@ -33,9 +33,9 @@ import { TestRunner } from './testbed/TestRunner'
 class TestExecutor implements UserInteraction {
 
   private isRunning = false
-  private readonly onShowPrompt: (context: TestContext, message: string, duration: TestPromptDuration) => Promise<void>
+  private readonly onShowPrompt: (context: TestContext, message: string, duration: UserPromptDuration) => Promise<void>
 
-  constructor(showPrompt: (context: TestContext, message: string, duration: TestPromptDuration) => Promise<void>) {
+  constructor(showPrompt: (context: TestContext, message: string, duration: UserPromptDuration) => Promise<void>) {
     this.onShowPrompt = showPrompt
     this.runTests(false)
   }
@@ -56,7 +56,7 @@ class TestExecutor implements UserInteraction {
     this.isRunning = false
   }
 
-  async showPrompt(context: TestContext, message: string, duration: TestPromptDuration): Promise<void> {
+  async showPrompt(context: TestContext, message: string, duration: UserPromptDuration): Promise<void> {
     return await this.onShowPrompt(context, message, duration)
   }
 }
@@ -78,7 +78,14 @@ class App extends Component<Props, State> {
 
   executor = new TestExecutor(async (_context, message, duration) => {
     this.setState({ promptMessage: message })
-    const sleepDuration = (duration === TestPromptDuration.SHORT) ? 2000 : 5000
+    let sleepDuration: number
+    if (duration === UserPromptDuration.QUICK) {
+       sleepDuration = 500
+    } else if (duration === UserPromptDuration.SHORT) {
+      sleepDuration = 2000
+    } else {
+      sleepDuration = 5000
+    }
     await new Promise<void>(resolve => setTimeout(resolve, sleepDuration)) 
     this.setState({ promptMessage: ' '})
   })
@@ -94,7 +101,7 @@ class App extends Component<Props, State> {
   render() {
     return (
       <SafeAreaView style={styles.container}>
-        <View style={{ height: 120 }}>
+        <View style={styles.promptContainer}>
           <Text style={styles.promptText}>
             { this.state.promptMessage ?? ' ' }
           </Text>
@@ -133,7 +140,11 @@ class App extends Component<Props, State> {
   promptText: {
     marginVertical: 16,
     fontSize: 20,
-    textAlign: 'center'
+    textAlign: 'center',
+    color: '#FF0000'
+  },
+  promptContainer: {
+    height: 120
   }
 })
  

--- a/testapp/src/testbed/TestInteraction.ts
+++ b/testapp/src/testbed/TestInteraction.ts
@@ -16,13 +16,14 @@
 
 import { TestContext } from "./TestSuite"
 
-export enum TestPromptDuration {
+export enum UserPromptDuration {
+    QUICK,
     SHORT,
     LONG
 }
 
 export interface UserInteraction {
-    showPrompt(context: TestContext, message: string, duration: TestPromptDuration): Promise<void>
+    showPrompt(context: TestContext, message: string, duration: UserPromptDuration): Promise<void>
 }
 
 export interface TestInteraction extends UserInteraction {

--- a/testapp/src/testbed/TestProgress.ts
+++ b/testapp/src/testbed/TestProgress.ts
@@ -17,12 +17,12 @@
 /**
  * Function that allows you observe progess of test.
  */
- export type TestProgressObserver = (progress: TestProgress) => void
+export type TestProgressObserver = (progress: TestProgress) => void
 
- /**
-  * Information about test progress.
-  */
- export interface TestProgress {
+/**
+ * Information about test progress.
+ */
+export interface TestProgress {
      readonly total: number
      readonly progress: number   // succeeded + failed + skipped
      readonly succeeded: number
@@ -35,86 +35,86 @@
  /**
   * Class providing TestProgress
   */
- export class TestCounter implements TestProgress {
-     readonly counterName: string
-     private _total: number
-     private _succeeded: number
-     private _failed: number
-     private _skipped: number
-     private _timestamp: number
-     private observers: TestProgressObserver[]
+export class TestCounter implements TestProgress {
+    readonly counterName: string
+    private _total: number
+    private _succeeded: number
+    private _failed: number
+    private _skipped: number
+    private _timestamp: number
+    private observers: TestProgressObserver[]
  
-     get total(): number { return this._total }
-     get succeeded(): number { return this._succeeded }
-     get failed(): number { return this._failed }
-     get skipped(): number { return this._skipped }
- 
-     get progress(): number {
-         return this._succeeded + this._failed + this._skipped
-     }
+    get total(): number { return this._total }
+    get succeeded(): number { return this._succeeded }
+    get failed(): number { return this._failed }
+    get skipped(): number { return this._skipped }
 
-     get elapsedTime(): number {
-        return (Date.now() - this._timestamp) * 0.001
-     }
+    get progress(): number {
+        return this._succeeded + this._failed + this._skipped
+    }
+
+    get elapsedTime(): number {
+       return (Date.now() - this._timestamp) * 0.001
+    }
  
-     constructor(counterName: string, total: number = 0) {
-         this.counterName = counterName
-         this._total = total
-         this._succeeded = 0
-         this._failed = 0
-         this._skipped = 0
-         this._timestamp = 0
-         this.observers = []
-     }
+    constructor(counterName: string, total: number = 0) {
+        this.counterName = counterName
+        this._total = total
+        this._succeeded = 0
+        this._failed = 0
+        this._skipped = 0
+        this._timestamp = 0
+        this.observers = []
+    }
  
-     restart(total: number) {
-         this._total = total
-         this._succeeded = 0
-         this._failed = 0
-         this._skipped = 0
-         this._timestamp = Date.now()
-         this.notify('restart')
-     }
+    restart(total: number) {
+        this._total = total
+        this._succeeded = 0
+        this._failed = 0
+        this._skipped = 0
+        this._timestamp = Date.now()
+        this.notify('restart')
+    }
  
-     resetObservers() {
-         this.observers = []
-     }
+    resetObservers() {
+        this.observers = []
+    }
  
-     addFailed(amount: number = 1) {
-         this._failed += amount
-         this.notify('addFailed')
-     }
+    addFailed(amount: number = 1) {
+        this._failed += amount
+        this.notify('addFailed')
+    }
+
+    addSucceeded(amount: number = 1) {
+        this._succeeded += amount
+        this.notify('addSucceeded')
+    }
  
-     addSucceeded(amount: number = 1) {
-         this._succeeded += amount
-         this.notify('addSucceeded')
-     }
- 
-     addSkipped(amount: number = 1) {
-         this._skipped += amount
-         this.notify('addSkipped')
-     }
- 
-     addObserver(observer: TestProgressObserver) {
-         this.observers.push(observer)
-     }
- 
-     private notify(op: string) {
-         if (this.succeeded + this.skipped + this.failed > this.total) {
-             throw new Error(`Internal error. Counter '${this.counterName}' exceeded its maximum value ${this.total} after ${op}`)
-         }
-         if (this._timestamp == 0) {
-            throw new Error(`Internal error. Counter '${this.counterName}' is not restarted before ${op}.`)
+    addSkipped(amount: number = 1) {
+        this._skipped += amount
+        this.notify('addSkipped')
+    }
+
+    addObserver(observer: TestProgressObserver) {
+        this.observers.push(observer)
+    }
+
+    private notify(op: string) {
+        if (this.succeeded + this.skipped + this.failed > this.total) {
+            throw new Error(`Internal error. Counter '${this.counterName}' exceeded its maximum value ${this.total} after ${op}`)
         }
-         const progress = {
+        if (this._timestamp == 0) {
+           throw new Error(`Internal error. Counter '${this.counterName}' is not restarted before ${op}.`)
+        }
+        const progress = {
             total: this.total,
             progress: this.progress,
             succeeded: this.succeeded,
             failed: this.failed,
             skipped: this.skipped,
             elapsedTime: this.elapsedTime
-         }
-         this.observers.forEach((observer) => observer(progress))
-     }
- }
+        }
+        this.observers.forEach((observer) => observer(progress))
+    }
+}
  

--- a/testapp/src/testbed/TestRunner.ts
+++ b/testapp/src/testbed/TestRunner.ts
@@ -18,7 +18,7 @@ import { Platform } from "react-native";
 import { TestConfig } from "../Config";
 import { describeError } from "./private/ErrorHelper";
 import { getAllObjectMethods } from "./private/ObjectHelper";
-import { TestInteraction, UserInteraction, TestPromptDuration } from "./TestInteraction";
+import { TestInteraction, UserInteraction, UserPromptDuration } from "./TestInteraction";
 import { TestEvent, TestMonitor } from "./TestMonitor";
 import { TestCounter } from "./TestProgress";
 import { TestContext, TestMethod, TestSuite } from "./TestSuite";
@@ -468,7 +468,7 @@ class RunnerContext implements TestInteraction {
 
     // TestInteraction impl.
 
-    async showPrompt(context: TestContext, message: string, duration: TestPromptDuration): Promise<void> {
+    async showPrompt(context: TestContext, message: string, duration: UserPromptDuration): Promise<void> {
         await this.validateContext(context, undefined, async () => {
             if (!this.interaction) {
                 throw new Error(`Interaction the user is not allowed for this test.`)

--- a/testapp/src/testbed/TestRunner.ts
+++ b/testapp/src/testbed/TestRunner.ts
@@ -262,7 +262,9 @@ class RunnerContext implements TestInteraction {
         this.isTestSkipped = this.isSkipped
         this.isTestFailed = this.isFailed
 
-        this.monitor.reportEvent(TestEvent.testStart(this.contextForTest(false)))
+        if (!this.isSkipped) {
+            this.monitor.reportEvent(TestEvent.testStart(this.contextForTest(false)))
+        }
         const ctx = this.contextForTest()
         try {
             if (!this.isSkipped && !this.isFailed) {

--- a/testapp/src/testbed/TestSuite.ts
+++ b/testapp/src/testbed/TestSuite.ts
@@ -208,6 +208,7 @@ export class TestSuite {
      * @returns Promise completed once the sleep time is over.
      */
     sleep(milliseconds: number): Promise<void> {
+        this.debugInfo(`Sleeping for ${milliseconds} ms`)
         return new Promise(resolve => setTimeout(resolve, milliseconds))
     }
 

--- a/testapp/src/testbed/TestSuite.ts
+++ b/testapp/src/testbed/TestSuite.ts
@@ -15,7 +15,7 @@
 //
 
 import { TestConfig } from "../Config"
-import { TestInteraction, TestPromptDuration, UserInteraction } from "./TestInteraction"
+import { TestInteraction, UserPromptDuration, UserInteraction } from "./TestInteraction"
 
 /**
  * Defines context for running test.
@@ -161,7 +161,7 @@ export class TestSuite {
      * @param message Message to show.
      * @param duration How long message will be displayed.
      */
-    showPrompt(message: string, duration: TestPromptDuration = TestPromptDuration.SHORT): Promise<void> {
+    showPrompt(message: string, duration: UserPromptDuration = UserPromptDuration.SHORT): Promise<void> {
         return this.interaction.showPrompt(this.context, message, duration)
     }
 

--- a/testapp/src/testbed/TestSuite.ts
+++ b/testapp/src/testbed/TestSuite.ts
@@ -15,7 +15,7 @@
 //
 
 import { TestConfig } from "../Config"
-import { TestInteraction, UserInteraction } from "./TestInteraction"
+import { TestInteraction, TestPromptDuration, UserInteraction } from "./TestInteraction"
 
 /**
  * Defines context for running test.
@@ -124,7 +124,6 @@ export class TestSuite {
     /**
      * Method executed before all tests in this test suite. You can override this method in subclass,
      * but you have to call parent's method in the implementation.
-     * @param context Test context.
      */
     async beforeAll() {
         this.debugInfo('beforeAll()')
@@ -133,7 +132,6 @@ export class TestSuite {
     /**
      * Method executed after all tests in this test suite. You can override this method in subclass,
      * but you have to call parent's method in the implementation.
-     * @param context Test context.
      */
     async afterAll() {
         this.debugInfo('afterAll()')
@@ -142,7 +140,6 @@ export class TestSuite {
     /**
      * Method executed before each test in this test suite. You can override this method in subclass,
      * but you have to call parent's method in the implementation.
-     * @param context Test context.
      */
     async beforeEach() {
         this.debugInfo('beforeEach()')
@@ -154,10 +151,18 @@ export class TestSuite {
     /**
      * Method executed after each test in this test suite. You can override this method in subclass,
      * but you have to call parent's method in the implementation.
-     * @param context Test context.
      */
     async afterEach() {
         this.debugInfo('afterEach()')
+    }
+
+    /**
+     * Show prompt to the user.
+     * @param message Message to show.
+     * @param duration How long message will be displayed.
+     */
+    showPrompt(message: string, duration: TestPromptDuration = TestPromptDuration.SHORT): Promise<void> {
+        return this.interaction.showPrompt(this.context, message, duration)
     }
 
     /**

--- a/testapp/src/testbed/private/CallStack.ts
+++ b/testapp/src/testbed/private/CallStack.ts
@@ -1,33 +1,18 @@
-import { Platform } from "react-native"
-
-// interface StackEntry {
-//     path: string;
-//     func: string;
-// }
-
-// function parseCallstackLine(line: string): StackEntry | undefined {
-//     if (line.indexOf('at') == -1) {
-//         return undefined
-//     }
-//     if (line === '@') return undefined;
-//     const idx = line.indexOf('@', 0);
-//     if (idx < 0) return undefined;
-//     const fname = line.substring(0, idx);
-//     if (fname.length == 0) return undefined;
-//     let locat = line.substring(idx + 1);
-//     if (locat === '[native code]') {
-//         return {path: 'native', func: fname};
-//     }
-//     if (locat.startsWith('http://')) {
-//         const bundleStart = locat.indexOf('/', 7);
-//         const bundleEnd = locat.indexOf('?', 7);
-//         locat = locat.substring(bundleStart + 1, bundleEnd);
-//         if (bundleStart < bundleEnd) {
-//             return {path: locat, func: fname};
-//         }
-//     }
-//     return undefined;
-// }
+//
+// Copyright 2022 Wultra s.r.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 
 export function parseRnCallStack(stack: string, padding: string = ""): string {
     const lines = stack.split('\n');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "strict": true
   },
   "exclude": [ "node_modules" ],
-  "include": [ "src/*.ts", "src/model/*.ts" ]
+  "include": [ "src/*.ts", "src/model/*.ts", "src/debug/*.ts" ]
 }


### PR DESCRIPTION
This PR adds native object register implementation for iOS platform. On top of that, there are a lot of changes in the native code:

- Resolved biometric key is no longer exposed to JS
- Added class that wraps NSData for object register.
- Extracted utilities from PowerAuth implementation to `Utilities.h` / `.m`
- Added constants for all error codes to `Errors.h`/ `.m`
- `PowerAuthSDK` instances are now managed by object register too.

The following changes were added to JS:

- Added `internal/AuthResolver.ts` module that's responsible for biometric key resolve.
- `PowerAuthDebug.ts` moved to `debug` folder.
- `debug/NativeObjectRegister.ts` expose register's internals for the testing purposes.
- `internal/NativeObject.ts` expose functions required for a regular SDK functionality.
- Added interactive tests to test biometry