### PR TITLE
Implement secure passwords

### DIFF
--- a/android/src/main/java/com/wultra/android/powerauth/reactnative/Constants.java
+++ b/android/src/main/java/com/wultra/android/powerauth/reactnative/Constants.java
@@ -37,4 +37,12 @@ class Constants {
      * Time interval in milliseconds to keep pre-authorized biometric key in memory.
      */
     static final int BIOMETRY_KEY_KEEP_ALIVE_TIME   = 10_000;
+    /**
+     * Time interval in milliseconds to keep password object valid in memory.
+     */
+    static final int PASSWORD_KEY_KEEP_ALIVE_TIME    = 5 * 60 * 1_000;
+    /**
+     * Upper limit for Unicode Code Point.
+     */
+    static final int CODEPOINT_MAX                   = 0x10FFFF;
 }

--- a/android/src/main/java/com/wultra/android/powerauth/reactnative/ObjectRegister.java
+++ b/android/src/main/java/com/wultra/android/powerauth/reactnative/ObjectRegister.java
@@ -42,6 +42,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.core.Password;
 import io.getlime.security.powerauth.exception.PowerAuthErrorException;
 
 /**
@@ -670,7 +671,7 @@ public class ObjectRegister extends BaseJavaModule {
                 // Note: This is not very accurate, but we're using this only for the debugging purposes
                 final long bootTime = System.currentTimeMillis() - currentTime();
                 map.putString("id", key);
-                map.putString("class", object.getClass().getSimpleName());
+                map.putString("class", object.managedInstance().getClass().getSimpleName());
                 map.putArray("policies", debugPolicies);
                 map.putBoolean("isValid", isStillValid());
                 if (tag != null) {
@@ -712,6 +713,8 @@ public class ObjectRegister extends BaseJavaModule {
                 objectClass = byte[].class;
             } else if ("number".equals(objectType)) {
                 objectClass = Integer.class;
+            } else if ("password".equals(objectType)) {
+                objectClass = Password.class;
             }
             if ("create".equals(command)) {
                 // The "create" command creates a new instance of managed object
@@ -744,6 +747,8 @@ public class ObjectRegister extends BaseJavaModule {
                         instance = ManagedAny.wrap("SECURE-DATA".getBytes(StandardCharsets.UTF_8));
                     } else if ("number".equals(objectType)) {
                         instance = ManagedAny.wrap(42);
+                    } else if ("password".equals(objectType)) {
+                        instance = ManagedAny.wrap(new Password(), Password::destroy);
                     }
                     if (instance != null) {
                         promise.resolve(registerObject(instance, objectTag, policies));

--- a/android/src/main/java/com/wultra/android/powerauth/reactnative/PowerAuthPasswordModule.java
+++ b/android/src/main/java/com/wultra/android/powerauth/reactnative/PowerAuthPasswordModule.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2022 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wultra.android.powerauth.reactnative;
+
+import com.facebook.react.bridge.BaseJavaModule;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.module.annotations.ReactModule;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.getlime.security.powerauth.core.Password;
+
+@SuppressWarnings("unused")
+@ReactModule(name = "PowerAuthPassword")
+public class PowerAuthPasswordModule extends BaseJavaModule {
+
+    private final ObjectRegister objectRegister;
+
+    public PowerAuthPasswordModule(@NonNull ObjectRegister objectRegister) {
+        super();
+        this.objectRegister = objectRegister;
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "PowerAuthPassword";
+    }
+
+    @ReactMethod
+    public void initialize(boolean destroyOnUse, @Nullable String ownerId, int autoreleaseTime, Promise promise) {
+        if (ownerId != null && !objectRegister.containsObject(ownerId)) {
+            promise.reject(Errors.EC_INSTANCE_NOT_CONFIGURED, "PowerAuth instance is not configured");
+            return;
+        }
+        int releaseTime = Constants.PASSWORD_KEY_KEEP_ALIVE_TIME;
+        if (BuildConfig.DEBUG) {
+            if (autoreleaseTime != 0) {
+                releaseTime = Math.min(autoreleaseTime, Constants.PASSWORD_KEY_KEEP_ALIVE_TIME);
+            }
+        }
+        final ManagedAny<Password> instance = ManagedAny.wrap(new Password(), Password::destroy);
+        final List<ReleasePolicy> releasePolicies = destroyOnUse
+                ? Arrays.asList(ReleasePolicy.afterUse(1), ReleasePolicy.keepAlive(releaseTime))
+                : Collections.singletonList(ReleasePolicy.keepAlive(releaseTime));
+        promise.resolve(objectRegister.registerObject(instance, ownerId, releasePolicies));
+    }
+
+    @ReactMethod
+    public void release(String objectId, Promise promise) {
+        objectRegister.removeObject(objectId, Password.class);
+        promise.resolve(null);
+    }
+
+    @ReactMethod
+    public void clear(String objectId, Promise promise) {
+        withPassword(objectId, promise, password -> {
+            password.clear();
+            promise.resolve(null);
+        });
+    }
+
+    @ReactMethod
+    public void length(String objectId, Promise promise) {
+        withPassword(objectId, promise, password -> {
+            promise.resolve(password.length());
+        });
+    }
+
+    @ReactMethod
+    public void isEqual(String id1, String id2, Promise promise) {
+        withPassword(id1, promise, p1 -> {
+            withPassword(id2, promise, p2 -> {
+                promise.resolve(p1.isEqualToPassword(p2));
+            });
+        });
+    }
+
+    @ReactMethod
+    public void addCharacter(String objectId, int character, Promise promise) {
+        withPassword(objectId, character, promise, (password, codePoint) -> {
+            password.addCharacter(codePoint);
+            promise.resolve(password.length());
+        });
+    }
+
+    @ReactMethod
+    public void insertCharacter(String objectId, int character, int position, Promise promise) {
+        withPassword(objectId, character, promise, (password, codePoint) -> {
+            if (position >= 0 && position <= password.length()) {
+                password.insertCharacter(codePoint, position);
+                promise.resolve(password.length());
+            } else {
+                promise.reject(Errors.EC_WRONG_PARAMETER, "Position is out of range");
+            }
+        });
+    }
+
+    @ReactMethod
+    public void removeCharacter(String objectId, int position, Promise promise) {
+        withPassword(objectId, promise, password -> {
+            if (position >= 0 && position < password.length()) {
+                password.removeCharacter(position);
+                promise.resolve(password.length());
+            } else {
+                promise.reject(Errors.EC_WRONG_PARAMETER, "Position is out of range");
+            }
+        });
+    }
+
+    @ReactMethod
+    public void removeLastCharacter(String objectId, Promise promise) {
+        withPassword(objectId, promise, password -> {
+            password.removeLastCharacter();
+            promise.resolve(password.length());
+        });
+    }
+
+    // Private methods
+
+    /**
+     * Action to execute when password object is found in object register.
+     */
+    private interface Action {
+        void action(@NonNull Password password);
+    }
+
+    /**
+     * Execute action when Password is found in object register.
+     * @param objectId Password object identifier.
+     * @param promise Promise to reject or resolve.
+     * @param action Action to execute.
+     */
+    private void withPassword(String objectId, final Promise promise, final @NonNull Action action) {
+        final Password password = objectRegister.touchObject(objectId, Password.class);
+        if (password != null) {
+            action.action(password);
+        } else {
+            promise.reject(Errors.EC_INVALID_NATIVE_OBJECT, "Password object is no longer valid");
+        }
+    }
+
+    /**
+     * Action to execute with valid code point, when password object is found in object register.
+     */
+    private interface CharacterAction {
+        void action(@NonNull Password password, int codePoint);
+    }
+
+    /**
+     * Execute action when Password is found in object register.
+     * @param objectId Password object identifier.
+     * @param character Character that represents an unicode code point.
+     * @param promise Promise to reject or resolve.
+     * @param action Action to execute.
+     */
+    private void withPassword(String objectId, int character, final Promise promise, final @NonNull CharacterAction action) {
+        if (character < 0 || character > Constants.CODEPOINT_MAX) {
+            promise.reject(Errors.EC_WRONG_PARAMETER, "Invalid CodePoint");
+            return;
+        }
+        final Password password = objectRegister.touchObject(objectId, Password.class);
+        if (password != null) {
+            action.action(password, character);
+        } else {
+            promise.reject(Errors.EC_INVALID_NATIVE_OBJECT, "Password object is no longer valid");
+        }
+    }
+}

--- a/android/src/main/java/com/wultra/android/powerauth/reactnative/PowerAuthReactPackage.java
+++ b/android/src/main/java/com/wultra/android/powerauth/reactnative/PowerAuthReactPackage.java
@@ -28,7 +28,7 @@ import java.util.Collections;
 import java.util.List;
 
 @SuppressWarnings("unused")
-public class PowerAuthRNPackage implements ReactPackage {
+public class PowerAuthReactPackage implements ReactPackage {
 
     @NonNull
     @Override
@@ -40,8 +40,10 @@ public class PowerAuthRNPackage implements ReactPackage {
     @Override
     public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();
-        modules.add(new PowerAuthRNModule(reactContext));
-        modules.add(new ObjectRegister());
+        final ObjectRegister objectRegister = new ObjectRegister();
+        modules.add(new PowerAuthModule(reactContext, objectRegister));
+        modules.add(new PowerAuthPasswordModule(objectRegister));
+        modules.add(objectRegister);
         return modules;
     }
 }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -10,5 +10,5 @@ target 'PowerAuth' do
   use_react_native!(
     :path => config["reactNativePath"]
   )
-  pod 'PowerAuth2', '~> 1.7.3'  
+  pod 'PowerAuth2', '~> 1.7.4'  
 end

--- a/ios/PowerAuth.xcodeproj/project.pbxproj
+++ b/ios/PowerAuth.xcodeproj/project.pbxproj
@@ -17,9 +17,11 @@
 		BF1F65A928F810880093A45A /* PowerAuthData.m in Sources */ = {isa = PBXBuildFile; fileRef = BF1F65A728F810880093A45A /* PowerAuthData.m */; };
 		BF1F65AB28F8464B0093A45A /* PowerAuthObjectRegister+JS.m in Sources */ = {isa = PBXBuildFile; fileRef = BF1F65AA28F8464B0093A45A /* PowerAuthObjectRegister+JS.m */; };
 		BF1F65AE28F9581F0093A45A /* Constants.h in Headers */ = {isa = PBXBuildFile; fileRef = BF1F65AC28F9581F0093A45A /* Constants.h */; };
+		BFAEDB6C29017F5E00E65B40 /* PowerAuthPasswordModule.h in Headers */ = {isa = PBXBuildFile; fileRef = BFAEDB6A29017F5E00E65B40 /* PowerAuthPasswordModule.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		BFAEDB6D29017F5E00E65B40 /* PowerAuthPasswordModule.m in Sources */ = {isa = PBXBuildFile; fileRef = BFAEDB6B29017F5E00E65B40 /* PowerAuthPasswordModule.m */; };
 		CAC0BE336028DD00272CEB09 /* libPods-PowerAuth.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D3CE2470A643546DD46BA726 /* libPods-PowerAuth.a */; };
-		DCEDF08B249E59EF00918481 /* PowerAuth.h in Headers */ = {isa = PBXBuildFile; fileRef = DCEDF089249E59EF00918481 /* PowerAuth.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		DCEDF092249E5A8600918481 /* PowerAuth.m in Sources */ = {isa = PBXBuildFile; fileRef = DCEDF091249E5A8600918481 /* PowerAuth.m */; };
+		DCEDF08B249E59EF00918481 /* PowerAuthModule.h in Headers */ = {isa = PBXBuildFile; fileRef = DCEDF089249E59EF00918481 /* PowerAuthModule.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		DCEDF092249E5A8600918481 /* PowerAuthModule.m in Sources */ = {isa = PBXBuildFile; fileRef = DCEDF091249E5A8600918481 /* PowerAuthModule.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -35,11 +37,13 @@
 		BF1F65A728F810880093A45A /* PowerAuthData.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PowerAuthData.m; sourceTree = "<group>"; };
 		BF1F65AA28F8464B0093A45A /* PowerAuthObjectRegister+JS.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "PowerAuthObjectRegister+JS.m"; sourceTree = "<group>"; };
 		BF1F65AC28F9581F0093A45A /* Constants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Constants.h; sourceTree = "<group>"; };
+		BFAEDB6A29017F5E00E65B40 /* PowerAuthPasswordModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PowerAuthPasswordModule.h; sourceTree = "<group>"; };
+		BFAEDB6B29017F5E00E65B40 /* PowerAuthPasswordModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PowerAuthPasswordModule.m; sourceTree = "<group>"; };
 		D3CE2470A643546DD46BA726 /* libPods-PowerAuth.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PowerAuth.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCEDF086249E59EF00918481 /* PowerAuth.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PowerAuth.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		DCEDF089249E59EF00918481 /* PowerAuth.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PowerAuth.h; sourceTree = "<group>"; };
+		DCEDF089249E59EF00918481 /* PowerAuthModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PowerAuthModule.h; sourceTree = "<group>"; };
 		DCEDF08A249E59EF00918481 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		DCEDF091249E5A8600918481 /* PowerAuth.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PowerAuth.m; sourceTree = "<group>"; };
+		DCEDF091249E5A8600918481 /* PowerAuthModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PowerAuthModule.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,13 +101,15 @@
 				BF1F65A328F80CF80093A45A /* Utilities.m */,
 				BF1F659E28F6EF900093A45A /* Errors.h */,
 				BF1F659F28F6EF900093A45A /* Errors.m */,
+				BF1F65A628F810880093A45A /* PowerAuthData.h */,
+				BF1F65A728F810880093A45A /* PowerAuthData.m */,
 				BF1F659A28F587B40093A45A /* PowerAuthObjectRegister.h */,
 				BF1F659B28F587B40093A45A /* PowerAuthObjectRegister.m */,
 				BF1F65AA28F8464B0093A45A /* PowerAuthObjectRegister+JS.m */,
-				BF1F65A628F810880093A45A /* PowerAuthData.h */,
-				BF1F65A728F810880093A45A /* PowerAuthData.m */,
-				DCEDF089249E59EF00918481 /* PowerAuth.h */,
-				DCEDF091249E5A8600918481 /* PowerAuth.m */,
+				BFAEDB6A29017F5E00E65B40 /* PowerAuthPasswordModule.h */,
+				BFAEDB6B29017F5E00E65B40 /* PowerAuthPasswordModule.m */,
+				DCEDF089249E59EF00918481 /* PowerAuthModule.h */,
+				DCEDF091249E5A8600918481 /* PowerAuthModule.m */,
 				DCEDF08A249E59EF00918481 /* Info.plist */,
 			);
 			path = PowerAuth;
@@ -116,11 +122,12 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DCEDF08B249E59EF00918481 /* PowerAuth.h in Headers */,
+				DCEDF08B249E59EF00918481 /* PowerAuthModule.h in Headers */,
 				BF1F65A828F810880093A45A /* PowerAuthData.h in Headers */,
 				BF1F65AE28F9581F0093A45A /* Constants.h in Headers */,
 				BF1F65A428F80CF80093A45A /* Utilities.h in Headers */,
 				BF1F65A028F6EF900093A45A /* Errors.h in Headers */,
+				BFAEDB6C29017F5E00E65B40 /* PowerAuthPasswordModule.h in Headers */,
 				BF1F659C28F587B40093A45A /* PowerAuthObjectRegister.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -239,10 +246,11 @@
 			files = (
 				BF1F659D28F587B40093A45A /* PowerAuthObjectRegister.m in Sources */,
 				BF1F65A928F810880093A45A /* PowerAuthData.m in Sources */,
-				DCEDF092249E5A8600918481 /* PowerAuth.m in Sources */,
+				DCEDF092249E5A8600918481 /* PowerAuthModule.m in Sources */,
 				BF1F65A528F80CF80093A45A /* Utilities.m in Sources */,
 				BF1F65AB28F8464B0093A45A /* PowerAuthObjectRegister+JS.m in Sources */,
 				BF1F65A128F6EF900093A45A /* Errors.m in Sources */,
+				BFAEDB6D29017F5E00E65B40 /* PowerAuthPasswordModule.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/PowerAuth/Constants.h
+++ b/ios/PowerAuth/Constants.h
@@ -20,6 +20,13 @@
 /// key in memory.
 #define BIOMETRY_KEY_KEEP_ALIVE_TIME    10000
 
+/// Time interval in milliseconds to keep password object valid
+/// in memory.
+#define PASSWORD_KEY_KEEP_ALIVE_TIME    (5 * 60 * 1000)
+
+/// Upper limit for Unicode Code Point
+#define CODEPOINT_MAX                    0x10FFFF
+
 /// Default period in milliseconds for automatic objects cleanup job.
 #define CLEANUP_PERIOD_DEFAULT          10000
 /// Minimum allowed period for automatic objects cleanup job.

--- a/ios/PowerAuth/PowerAuthModule.h
+++ b/ios/PowerAuth/PowerAuthModule.h
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2020 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <React/RCTBridgeModule.h>
+#import <React/RCTInitializing.h>
+#import "PowerAuthObjectRegister.h"
+
+@interface PowerAuthModule: NSObject<RCTBridgeModule, RCTInitializing>
+
+@end

--- a/ios/PowerAuth/PowerAuthObjectRegister+JS.m
+++ b/ios/PowerAuth/PowerAuthObjectRegister+JS.m
@@ -20,6 +20,8 @@
 #import <React/RCTConvert.h>
 #import <React/RCTInvalidating.h>
 
+@import PowerAuthCore;
+
 /*
  This class category exports several debug methods to JavaScript.
  The 'debug' methods are available only if library is compiled in DEBUG configuration.
@@ -75,6 +77,8 @@ RCT_EXPORT_METHOD(debugCommand:(NSString*)command
         objectClass = [PowerAuthData class];
     } else if ([@"number" isEqual:objectType]) {
         objectClass = [NSNumber class];
+    } else if ([@"password" isEqual:objectType]) {
+        objectClass = [PowerAuthCoreMutablePassword class];
     }
     if ([@"create" isEqual:command]) {
         // The "create" command creates a new instance of managed object
@@ -106,6 +110,8 @@ RCT_EXPORT_METHOD(debugCommand:(NSString*)command
                 instance = [[PowerAuthData alloc] initWithData:td cleanup:YES];
             } else if ([@"number" isEqual:objectType]) {
                 instance = [[NSNumber alloc] initWithInt:42];
+            } else if ([@"password" isEqual:objectType]) {
+                instance = [PowerAuthCoreMutablePassword mutablePassword];
             }
             if (instance) {
                 NSString * objectId = [self registerObject:instance tag:objectTag policies:policies];
@@ -132,9 +138,15 @@ RCT_EXPORT_METHOD(debugCommand:(NSString*)command
             return;
         }
     } else if ([@"find" isEqual:command]) {
-        // The "find" command just find the object in the register and returns true / false.
+        // The "find" command just find the object in the register and returns true / false if object still exists.
         if (objectClass && objectId) {
             resolve([self findObjectWithId:objectId expectedClass:objectClass] != nil ? @YES : @NO);
+            return;
+        }
+    } else if ([@"touch" isEqual:command]) {
+        // The "touch" command prolongs lifetime of object in the register and returns true / false if object still exists.
+        if (objectClass && objectId) {
+            resolve([self touchObjectWithId:objectId expectedClass:objectClass] != nil ? @YES : @NO);
             return;
         }
     } else if ([@"setPeriod" isEqual:command]) {

--- a/ios/PowerAuth/PowerAuthObjectRegister.h
+++ b/ios/PowerAuth/PowerAuthObjectRegister.h
@@ -56,6 +56,14 @@
                    expectedClass:(nonnull Class)expectedClass;
 
 /**
+ Find object with given identifier and prolong its lifetime if `RP_KEEP_ALIVE` policy is specified.
+ The identifier may be auto-generated or application specific. This method doesn't increase object's
+ usage count, so it will not cause an object relase.
+ */
+- (nullable id) touchObjectWithId:(nonnull NSString*)objectId
+                    expectedClass:(nonnull Class)expectedClass;
+
+/**
  Find object with given identifier and increase its usage counter.
  */
 - (nullable id) useObjectWithId:(nonnull NSString*)objectId

--- a/ios/PowerAuth/PowerAuthPasswordModule.h
+++ b/ios/PowerAuth/PowerAuthPasswordModule.h
@@ -1,5 +1,5 @@
-/**
- * Copyright 2020 Wultra s.r.o.
+/*
+ * Copyright 2022 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
 
 #import <React/RCTBridgeModule.h>
 #import <React/RCTInitializing.h>
-#import "PowerAuthObjectRegister.h"
 
-@interface PowerAuth: NSObject<RCTBridgeModule, RCTInitializing>
+/**
+ Bridge module implementing PowerAuthPassword JavaScript class.
+ */
+@interface PowerAuthPasswordModule :  NSObject<RCTBridgeModule, RCTInitializing>
 
 @end

--- a/ios/PowerAuth/PowerAuthPasswordModule.m
+++ b/ios/PowerAuth/PowerAuthPasswordModule.m
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2022 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "PowerAuthPasswordModule.h"
+#import "PowerAuthObjectRegister.h"
+#import "Utilities.h"
+#import "Constants.h"
+
+#import <React/RCTConvert.h>
+
+@import PowerAuthCore;
+
+@implementation PowerAuthPasswordModule
+{
+    PowerAuthObjectRegister * _objectRegister;
+}
+
+// MARK: - ReactNative bridge
+
+@synthesize moduleRegistry = _moduleRegistry;
+
+RCT_EXPORT_MODULE(PowerAuthPassword);
+
+- (void) initialize
+{
+    // RCTInitializing protocol allows us to get module dependencies before the object is used from JS.
+    _objectRegister = [_moduleRegistry moduleForName:"PowerAuthObjectRegister"];
+}
+
++ (BOOL) requiresMainQueueSetup
+{
+    return NO;
+}
+
+// MARK: - JS interface
+
+RCT_EXPORT_METHOD(initialize:(BOOL)destroyAfterUse
+                  ownerId:(NSString*)ownerId
+                  autoreleaseTime:(nonnull NSNumber*)autoreleaseTime
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    NSString * powerAuthInstanceId = [RCTConvert NSString: ownerId];
+    // If owning PowerAuth instnace is specified, then make sure it still exists
+    if (powerAuthInstanceId && ![_objectRegister containsObjectWithId:powerAuthInstanceId]) {
+        reject(EC_INSTANCE_NOT_CONFIGURED, @"PowerAuth instance is not configured", nil);
+        return;
+    }
+    NSUInteger releaseTime = PASSWORD_KEY_KEEP_ALIVE_TIME;
+#if DEBUG
+    autoreleaseTime = [RCTConvert NSNumber:autoreleaseTime];
+    if (autoreleaseTime) {
+        releaseTime = [autoreleaseTime unsignedIntegerValue];
+        // Ignore zero result and make sure that time doesn't exceed 5 minutes
+        if (releaseTime) {
+            releaseTime = MIN(releaseTime, PASSWORD_KEY_KEEP_ALIVE_TIME);
+        } else {
+            releaseTime = PASSWORD_KEY_KEEP_ALIVE_TIME;
+        }
+    }
+#endif // DEBUG
+    // Now create and register a new password object
+    NSArray * policies = destroyAfterUse
+        ? @[ RP_KEEP_ALIVE(releaseTime), RP_AFTER_USE(1) ]
+        : @[ RP_KEEP_ALIVE(releaseTime) ];
+    resolve([_objectRegister registerObject:[PowerAuthCoreMutablePassword mutablePassword]
+                                        tag:powerAuthInstanceId
+                                   policies:policies]);
+}
+
+RCT_EXPORT_METHOD(release:(NSString*)objectId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [_objectRegister removeObjectWithId:objectId expectedClass:[PowerAuthCoreMutablePassword class]];
+    resolve(nil);
+}
+
+RCT_EXPORT_METHOD(clear:(NSString*)objectId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [self withPassword:objectId rejecter:reject action:^(PowerAuthCoreMutablePassword *password) {
+        [password clear];
+        resolve(nil);
+    }];
+}
+
+RCT_EXPORT_METHOD(length:(NSString*)objectId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [self withPassword:objectId rejecter:reject action:^(PowerAuthCoreMutablePassword *password) {
+        resolve(@([password length]));
+    }];
+}
+
+RCT_EXPORT_METHOD(isEqual:(NSString*)id1
+                  id2:(NSString*)id2
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [self withPassword:id1 rejecter:reject action:^(PowerAuthCoreMutablePassword *password1) {
+        [self withPassword:id2 rejecter:reject action:^(PowerAuthCoreMutablePassword *password2) {
+            resolve([password1 isEqualToPassword:password2] ? @YES : @NO);
+        }];
+    }];
+}
+
+RCT_EXPORT_METHOD(addCharacter:(NSString*)objectId
+                  character:(nonnull NSNumber*)character
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [self withPassword:objectId character:character rejecter:reject action:^(PowerAuthCoreMutablePassword *password, UInt32 character) {
+        [password addCharacter:character];
+        resolve(@(password.length));
+    }];
+}
+
+RCT_EXPORT_METHOD(insertCharacter:(NSString*)objectId
+                  character:(nonnull NSNumber*)character
+                  position:(nonnull NSNumber*)position
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [self withPassword:objectId character:character rejecter:reject action:^(PowerAuthCoreMutablePassword *password, UInt32 character) {
+        NSInteger pos = [[RCTConvert NSNumber:position] integerValue];
+        if (pos >= 0 && pos <= password.length) {
+            [password insertCharacter:character atIndex:pos];
+            resolve(@(password.length));
+        } else {
+            reject(EC_WRONG_PARAMETER, @"Position is out of range", nil);
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(removeCharacter:(NSString*)objectId
+                  position:(nonnull NSNumber*)position
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [self withPassword:objectId rejecter:reject action:^(PowerAuthCoreMutablePassword *password) {
+        NSInteger pos = [[RCTConvert NSNumber:position] integerValue];
+        if (pos >= 0 && pos < password.length) {
+            [password removeCharacterAtIndex:pos];
+            resolve(@(password.length));
+        } else {
+            reject(EC_WRONG_PARAMETER, @"Position is out of range", nil);
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(removeLastCharacter:(NSString*)objectId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    [self withPassword:objectId rejecter:reject action:^(PowerAuthCoreMutablePassword *password) {
+        [password removeLastCharacter];
+        resolve(@(password.length));
+    }];
+}
+
+// MARK: - Private interface
+
+- (void) withPassword:(NSString*)passwordId
+             rejecter:(RCTPromiseRejectBlock)reject
+               action:(NS_NOESCAPE void(^)(PowerAuthCoreMutablePassword * password))action
+{
+    PowerAuthCoreMutablePassword * password = [_objectRegister touchObjectWithId:passwordId expectedClass:[PowerAuthCoreMutablePassword class]];
+    if (password) {
+        action(password);
+    } else {
+        reject(EC_INVALID_NATIVE_OBJECT, @"Password object is no longer valid", nil);
+    }
+}
+
+- (void) withPassword:(NSString*)passwordId
+            character:(NSNumber*)character
+             rejecter:(RCTPromiseRejectBlock)reject
+               action:(NS_NOESCAPE void(^)(PowerAuthCoreMutablePassword * password, UInt32 character))action
+{
+    NSNumber * cp = [RCTConvert NSNumber:character];
+    if (!cp) {
+        reject(EC_WRONG_PARAMETER, @"Empty or invalid character object", nil);
+        return;
+    }
+    NSUInteger codePoint = [cp unsignedIntValue];
+    if (codePoint > CODEPOINT_MAX) {
+        reject(EC_WRONG_PARAMETER, @"CodePoint is too big", nil);
+        return;
+    }
+    PowerAuthCoreMutablePassword * password = [_objectRegister touchObjectWithId:passwordId expectedClass:[PowerAuthCoreMutablePassword class]];
+    if (password) {
+        action(password, (UInt32)codePoint);
+    } else {
+        reject(EC_INVALID_NATIVE_OBJECT, @"Password object is no longer valid", nil);
+    }
+}
+
+@end

--- a/react-native-powerauth-mobile-sdk.podspec
+++ b/react-native-powerauth-mobile-sdk.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React"
-  s.dependency "PowerAuth2", "~> 1.7.3"
+  s.dependency "PowerAuth2", "~> 1.7.4"
 end

--- a/scripts/update-apps.sh
+++ b/scripts/update-apps.sh
@@ -9,9 +9,12 @@ REQUIRE_COMMAND "npm"
 LIB='react-native-powerauth-mobile-sdk'
 
 DO_TEST=1
+DO_RUN=0
 case $1 in
     test | testapp) 
         DO_TEST=1 ;;
+    run | -r)
+        DO_RUN=1 ;;
     *) 
         DO_TEST=1 ;;
 esac
@@ -63,6 +66,22 @@ function UPDATE_DEPENDENCIES
     PUSH_DIR "${SRC}/${APP_NAME}/ios"
     pod install
     POP_DIR
+
+    if [ x$DO_RUN == x1 ]; then
+        PUSH_DIR "${SRC}/${APP_NAME}"
+
+        LOG_LINE
+        LOG 'Starting Android app...'
+        LOG_LINE
+        npm run android
+
+        LOG_LINE
+        LOG 'Starting iOS app...'
+        LOG_LINE
+        npm run ios
+
+        POP_DIR
+    fi
 }
 
 LIB_PACKAGE

--- a/src/PowerAuth.ts
+++ b/src/PowerAuth.ts
@@ -31,6 +31,7 @@ import { PowerAuthConfirmRecoveryCodeDataResult} from './model/PowerAuthConfirmR
 import { PowerAuthTokenStore } from "./PowerAuthTokenStore"
 import { NativeWrapper } from "./internal/NativeWrapper";
 import { AuthResolver } from "./internal/AuthResolver";
+import { PasswordType, PowerAuthPassword } from './model/PowerAuthPassword';
 
 /**
  * Class used for the main interaction with the PowerAuth SDK components.
@@ -294,7 +295,7 @@ export class PowerAuth {
      * @param oldPassword Old password, currently set to store the data.
      * @param newPassword New password, to be set in case authentication with old password passes.
      */
-    changePassword(oldPassword: string, newPassword: string): Promise<void> {
+    changePassword(oldPassword: PasswordType, newPassword: PasswordType): Promise<void> {
         return NativeWrapper.thisCall("changePassword", this.instanceId, oldPassword, newPassword);
     }
 
@@ -309,7 +310,7 @@ export class PowerAuth {
      @param newPassword New password, to be set in case authentication with old password passes.
      @returns Returns true in case password was changed without error, false otherwise.
      */
-    unsafeChangePassword(oldPassword: string, newPassword: string): Promise<boolean> {
+    unsafeChangePassword(oldPassword: PasswordType, newPassword: PasswordType): Promise<boolean> {
         return NativeWrapper.thisCallBool("unsafeChangePassword", this.instanceId, oldPassword, newPassword);
     }
 
@@ -321,7 +322,7 @@ export class PowerAuth {
      * @param title (used only in Android) Title for biometry dialog
      * @param description (used only in Android) Description for biometry dialog
      */
-    addBiometryFactor(password: string, title: string, description: string): Promise<void> {
+    addBiometryFactor(password: PasswordType, title: string, description: string): Promise<void> {
         if (Platform.OS === 'android') {
             return NativeWrapper.thisCall("addBiometryFactor", this.instanceId, password, title, description);
         } else {
@@ -388,7 +389,7 @@ export class PowerAuth {
      * 
      * @param password Password to be verified.
      */
-    validatePassword(password: string): Promise<void> {
+    validatePassword(password: PasswordType): Promise<void> {
         return NativeWrapper.thisCall("validatePassword", this.instanceId, password);
     }
 
@@ -462,6 +463,16 @@ export class PowerAuth {
             // catching biometry authentication error and rethrowing it as PowerAuthError
             throw NativeWrapper.processException(e);
         }  
+    }
+
+    /**
+     * Create new PowerAuthPassword object that will be destroyed automatically when this PowerAuth instance is deconfigured.
+     * @param destroyOnUse If `true` then the underlying native password is destroyed immediately after it's used for a cryptographic operation.
+     * @param onAutomaticCleanup If provided, then the closure is called when the native password is restored and the previous content is lost.
+     * @returns new instance of PowerAuthPassword class that's owned by this PowerAuth instance.
+     */
+    createPassword(destroyOnUse: boolean = true, onAutomaticCleanup: (() => void) | undefined = undefined): PowerAuthPassword {
+        return new PowerAuthPassword(destroyOnUse, this.instanceId, onAutomaticCleanup)
     }
 
     /**

--- a/src/debug/NativeObjectRegister.ts
+++ b/src/debug/NativeObjectRegister.ts
@@ -45,7 +45,7 @@ export type NativeObjectCmd = 'create' | 'release' | 'releaseAll' | 'use' | 'fin
 /**
  * Native object types.
  */
-export type NativeObjectType = 'data' | 'secure-data' | 'number'
+export type NativeObjectType = 'data' | 'secure-data' | 'number' | 'password'
 /**
  * Data accepted in debugCommand() function. 
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export * from './model/PowerAuthCreateActivationResult';
 export * from './model/PowerAuthError';
 export * from './model/PowerAuthKeychainConfiguration';
 export * from './model/PowerAuthRecoveryActivationData';
+export * from './model/PowerAuthPassword';
 
 // Debug features
 

--- a/src/internal/NativePassword.ts
+++ b/src/internal/NativePassword.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NativeModules } from "react-native"
+
+/**
+ * Password interface implemented in the native code.
+ */
+interface PowerAuthPasswordIfc {
+    
+    /**
+     * Initialize native password object.
+     * @param destroyOnUse If `true`, then native password will be destroyed after its use for the cryptograhic operation.
+     * @param ownerId If specified, then native password will be destroyed together with owning PowerAuth instance.
+     * @param autoreleaseTime Defines autorelease timeout in milliseconds. The value is used only for the testing purposes, and is ignored in the release build of library.
+     * @returns Underlying native object identifier.
+     */
+    initialize(destroyOnUse: boolean, ownerId: string | undefined, autoreleaseTime: number): Promise<string>
+
+    /**
+     * Release native password object.
+     * @param objectId Underlying object identifier.
+     */
+    release(objectId: string): Promise<void>
+
+    /**
+     * Clear password content.
+     * @param objectId Underlying object identifier.
+     */
+    clear(objectId: string): Promise<void>
+    
+    /**
+     * Get number of stored characters.
+     * @param objectId Underlying object identifier.
+     */
+    length(objectId: string): Promise<number>
+
+    /**
+     * Compare two passwords.
+     * @param objectId1 Underlying object identifier.
+     * @param objectId2 Underlying object identifier.
+     */
+    isEqual(objectId1: string, objectId2: string): Promise<boolean>
+
+    /**
+     * Add character at the end of password and return the number of stored characters.
+     * @param objectId Underlying object identifier.
+     * @param character Character to add
+     */
+    addCharacter(objectId: string, character: number): Promise<number>
+    
+    /**
+     * Insert character at the specified position and return the number of stored characters.
+     * @param objectId Underlying object identifier.
+     * @param character Character to add.
+     * @param position Position where character will be added.
+     */
+    insertCharacter(objectId: string, character: number, position: number): Promise<number>
+
+    /**
+     * Remove character 
+     * @param objectId Underlying object identifier.
+     * @param position 
+     */
+    removeCharacter(objectId: string, position: number): Promise<number>
+    
+    /**
+     * 
+     * @param objectId Underlying object identifier.
+     */
+    removeLastCharacter(objectId: string): Promise<number>
+}
+
+export const NativePassword = NativeModules.PowerAuthPassword as PowerAuthPasswordIfc

--- a/src/internal/NativeWrapper.ts
+++ b/src/internal/NativeWrapper.ts
@@ -257,7 +257,7 @@ export class NativeWrapper {
  * @param originalPromise Original promise which result needs to be patched.
  * @returns Patched promise that always resolve to true or false.
  */
-function patchBool(originalPromise: Promise<boolean>): Promise<boolean> {
+export function patchBool(originalPromise: Promise<boolean>): Promise<boolean> {
     if (Platform.OS === 'android') {
         return originalPromise
     }
@@ -274,7 +274,7 @@ function patchBool(originalPromise: Promise<boolean>): Promise<boolean> {
  * @param originalPromise Original promise which result needs to be patched.
  * @returns Patched promise that always resolve to value or undefined.
  */
- function patchNull<T>(originalPromise: Promise<T | undefined>): Promise<T | undefined> {
+export function patchNull<T>(originalPromise: Promise<T | undefined>): Promise<T | undefined> {
     return new Promise((resolved, rejected) => {
         originalPromise
             .then(r => resolved(r ?? undefined))

--- a/src/model/PowerAuthAuthentication.ts
+++ b/src/model/PowerAuthAuthentication.ts
@@ -14,21 +14,31 @@
  * limitations under the License.
  */
 
+import { PasswordType } from "./PowerAuthPassword"
+
 /**
  * Class representing a multi-factor authentication object.
  */
 export class PowerAuthAuthentication {
-    /** Indicates if a possession factor should be used. */
-    usePossession: boolean = false
-    /** Indicates if a biometry factor should be used. */
+    /**
+     * Indicates if a possession factor should be used. 
+     */
+    usePossession: boolean = true
+    /**
+     * Indicates if a biometry factor should be used. 
+     */
     useBiometry: boolean = false
-    /** Password to be used for knowledge factor, or nil of knowledge factor should not be used */
-    userPassword?: string
+    /** 
+     * Password to be used for knowledge factor, or undefined if knowledge factor should not be used.
+     * You can use `PowerAuthPassword` object or regular `string` as an user's password.
+     */
+    userPassword?: PasswordType
     /**
      * Message displayed when prompted for biometric authentication
      */
     biometryMessage?: string
-
-    /** (Android only) Title of biometric prompt */
+    /**
+     * (Android only) Title of biometric prompt
+     */
     biometryTitle?: string
 };

--- a/src/model/PowerAuthPassword.ts
+++ b/src/model/PowerAuthPassword.ts
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2021 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PowerAuthError, PowerAuthErrorCode } from "../index"
+import { NativePassword } from "../internal/NativePassword"
+import { NativeWrapper } from "../internal/NativeWrapper"
+
+/**
+ * Type representing an user's password. You can use `PowerAuthPassword` object or
+ * a simple string as a password.
+ */
+export type PasswordType = PowerAuthPassword | string
+
+/**
+ * Type representing an one character passed to the `PowerAuthPassword` functions.
+ * If value is number type, then it representing an Unicode Code Point.  If you use 
+ * string, then only the first code point from the string will be processed.
+ */
+export type CharacterType = string | number
+
+/**
+ * The `PowerAuthPassword` class implements a safe storage for user's passwords.
+ * The class is using an underlying native object to store the user's password securely
+ * in the memory. The goal is to keep the user's password in the memory for as short 
+ * as possible time period. To achieve this, the native object implements the following
+ * precautions: 
+ * 
+ * - If it's constructed with `destroyOnUse` parameter set to `true` then the naive
+ *   password is automatically destroyed when it's used for the cryptographic operation.
+ * 
+ * - If it's constructed with `powerAuthInstanceId` then the native object will be
+ *   destroyed after the `PowerAuth` class with the same identifier is deconfigured.
+ * 
+ * - If you leave instnace of `PowerAuthPassword` class as it is, then the native 
+ *   password is removed from the memory after 5 minutes of inactivity. The JavaScript
+ *   object is still functional, so if you use any API function, then the native
+ *   password is re-initialized, but the previous passphrase is lost. You can provide
+ *   optional `onAutomaticCleanup` function to PowerAuthPassword's constructor
+ *   to detect such situation.  
+ * 
+ * - If you call any PowerAuthPassword method except `release()`, then the auto-cleanup
+ *   timer is reset, so the native password will live for another 5 minutes. 
+ * 
+ * If you're interested in more detail why the passwords should be protected in 
+ * the memory, then you can follow the [Working with passwrods securely](https://developers.wultra.com/components/powerauth-mobile-sdk/1.7.x/documentation/PowerAuth-SDK-for-iOS#working-with-passwords-securely)
+ * chapter from the PowerAuth mobile SDK.
+ */
+export class PowerAuthPassword {
+    /**
+     * Construct password object and specify whether it's re-usable and/or should be destroyed 
+     * together with the owning PowerAuth class instance.
+     * @param destroyOnUse If `true` then the native password is destroyed after is used for the cryptograhic operation.
+     * @param powerAuthInstanceId If specified, then the native password will be destroyed together with PowerAuth instance.
+     * @param onAutomaticCleanup If provided, then the closure is called when the native password is restored and the previous content is lost.
+     * @param autoreleaseTime Autorelease timeout in milliseconds. The value is used only for the testing purposes, and is ignored in the release build of library.
+     */
+    constructor(
+        destroyOnUse: boolean = true, 
+        powerAuthInstanceId: string | undefined = undefined,
+        onAutomaticCleanup: (() => void) | undefined = undefined,
+        autoreleaseTime: number = 0) {
+        this.destroyOnUse = destroyOnUse
+        this.powerAuthInstanceId = powerAuthInstanceId
+        this.autoreleaseTime = autoreleaseTime
+        this.onAutomaticCleanup = onAutomaticCleanup
+    }
+
+    /**
+     * Return number of characters stored in the pasword. This method also
+     * extends the lifetime of the underlying native password.
+     * 
+     * @returns Number of characters stored in the password.
+     */
+    length(): Promise<number> {
+        return this.withObjectId(id => NativePassword.length(id))
+    }
+
+    /**
+     * Clear content of the password.
+     */
+    clear(): Promise<void> {
+        return this.withObjectId(id => NativePassword.clear(id))
+    }
+
+    /**
+     * Determine whether the stored password is empty. This method also
+     * extends the lifetime of the underlying native password.
+     * 
+     * @returns `true` if password is empty.
+     */
+    async isEmpty(): Promise<boolean> {
+        return (await this.length()) == 0
+    }
+
+    /**
+     * Append character to the end of the password. This method also
+     * extends the lifetime of the underlying native password.
+     * 
+     * @param character Character to add at the end of password.
+     * @returns Number of characters stored in the password.
+     */
+    addCharacter(character: CharacterType): Promise<number> {
+        return this.withObjectId(id => NativePassword.addCharacter(id, getCodePoint(character)))
+    }
+
+    /**
+     * Insert character at the specified position. This method also
+     * extends the lifetime of the underlying native password.
+     * 
+     * @param character Character to insert.
+     * @param at Position where character will be inserted. Must be in range 0, upt to length, otherwise `PowerAuthErrorCode.WRONG_PARAMETER` error is reported.
+     * @returns Number of characters stored in the password.
+     */
+    insertCharacter(character: CharacterType, at: number): Promise<number> {
+        return this.withObjectId(id => NativePassword.insertCharacter(id, getCodePoint(character), at))
+    }
+
+    /**
+     * Remove character at the specified position. This method also
+     * extends the lifetime of the underlying native password.
+     * 
+     * @param position Position of character to be removed. Must be in range 0 up to length - 1, otherwise `PowerAuthErrorCode.WRONG_PARAMETER` error is reported.
+     * @returns Remaining number of characters stored in the password.
+     */
+    removeCharacterAt(position: number): Promise<number> {
+        return this.withObjectId(id => NativePassword.removeCharacter(id, position))
+    }
+
+    /**
+     * Remove last character and return the number of remaining characters stored in the password.
+     * This method also extends the lifetime of the underlying native password.
+     * 
+     * @returns Remaining number of characters stored in the password.
+     */
+    removeLastCharacter(): Promise<number> {
+        return this.withObjectId(id => NativePassword.removeLastCharacter(id))
+    }
+
+    /**
+     * Compare two passwords. This method also extends the lifetime of the both underlying
+     * native passwords.
+     * 
+     * @param password Password to compare with this instance.
+     * @returns true if both passwords contains an equal passphrase.
+     */
+    isEqualTo(password: PowerAuthPassword): Promise<boolean> {
+        return this.withObjectId(id1 => password.withObjectId(id2 => NativePassword.isEqual(id1, id2)))
+    }
+
+    /**
+     * Release the underlying native password object.
+     */
+    release(): Promise<void> {
+        if (this.passwordObjectId) {
+            const objId = this.passwordObjectId
+            this.passwordObjectId = undefined
+            return NativePassword.release(objId)
+        }
+        return Promise.resolve()
+    }
+
+    /**
+     * Acquire native password object ID and execute action with this identifier.
+     * @param action Action to execute after objectId is acquired.
+     * @param recoveringFromError If true, then this is 2nd attempt to execute action after recovery from action.
+     * @returns Promise result type.
+     */
+    private async withObjectId<T>(action: (objectId: string) => Promise<T>, recoveringFromError: boolean = false): Promise<T> {
+        try {
+            if (!this.passwordObjectId) {
+                this.passwordObjectId = await NativePassword.initialize(this.destroyOnUse, this.powerAuthInstanceId, this.autoreleaseTime)
+            }
+            return await action(this.passwordObjectId)
+        } catch (error: any) {
+            if (!recoveringFromError && error.code == PowerAuthErrorCode.INVALID_NATIVE_OBJECT) {
+                // Underlying native password has been already destroyed.
+                // We can recover from this situation by resetting identifier and retry the operation
+                this.passwordObjectId = undefined
+                // Call cleanup callback if it's defined
+                if (this.onAutomaticCleanup != undefined) {
+                    this.onAutomaticCleanup()
+                }
+                // Now try to repeat action.
+                return this.withObjectId(action, true)
+            }
+            // Otherwise simply process the exception and report the error.
+            throw NativeWrapper.processException(error)
+        }
+    }
+
+    /**
+     * If true, then the underlying native password will be destroyed immediately after is used
+     * for the cryptographic operation.
+     */
+    private readonly destroyOnUse: boolean
+    /**
+     * InstanceId of PowerAuth object that created this password.
+     */
+    private readonly powerAuthInstanceId?: string
+    /**
+     * Autorelease timeout in milliseconds. The value is used only for testing purposes, and is ignored in release build of library.
+     */
+    private readonly autoreleaseTime: number
+    /**
+     * Closure called when native object is restored and the content of previously stored password is lost.
+     */
+    private readonly onAutomaticCleanup?: () => void
+    /**
+     * Underlying native object's identifier.
+     */
+    private passwordObjectId?: string
+}
+
+/**
+ * Function translate string or number into unicode code point. If string parameter is provided,
+ * then the `codePointAt(0)` is returned.
+ * @param character CharacterType to translate. 
+ * @returns number with Unicode Code Point.
+ */
+function getCodePoint(character: CharacterType): number {
+    let c: number
+    if (typeof character === 'string') {
+        if (character.length === 0) {
+            throw new PowerAuthError(undefined, "String is empty", PowerAuthErrorCode.WRONG_PARAMETER)
+        }
+        const cp = character.codePointAt(0)
+        if (cp === undefined) {
+            throw new PowerAuthError(undefined, "Failed to extract 1st. code point", PowerAuthErrorCode.WRONG_PARAMETER)
+        }
+        c = cp
+    } else {
+        c = character
+    }
+    return c
+}

--- a/testapp/_tests/AllTests.ts
+++ b/testapp/_tests/AllTests.ts
@@ -30,6 +30,7 @@ import { PowerAuth_EncryptionTests } from "./PowerAuth_Encryption.test";
 import { PowerAuth_ConfigureTests } from "./PowerAuth_Configure.test";
 import { PowerAuth_Example } from "./PowerAuth_Example";
 import { NativeObjectRegisterTests } from "./NativeObjectRegister.test";
+import { PowerAuthPasswordTests } from "./PowerAuthPassword.test";
 
 export function getLibraryTests(): TestSuite[] {
     return [
@@ -44,6 +45,7 @@ export function getLibraryTests(): TestSuite[] {
         new PowerAuth_EncryptionTests(),
         new PowerAuthActivationTests(),
         new PowerAuthActivationCodeUtilTests(),
+        new PowerAuthPasswordTests(),
         new NativeObjectRegisterTests(),
     ]
 }

--- a/testapp/_tests/NativeObjectRegister.test.ts
+++ b/testapp/_tests/NativeObjectRegister.test.ts
@@ -15,80 +15,9 @@
 //
 
 import { expect } from "../src/testbed";
-import { PowerAuthDebug, NativeObjectRegister, NativeObjectType, NativeObjectCmdData, NativeObjectCmdResult } from "react-native-powerauth-mobile-sdk";
+import { PowerAuthDebug } from "react-native-powerauth-mobile-sdk";
 import { TestWithActivation } from "./helpers/TestWithActivation";
-
-interface ObjectsCount {
-    valid: number
-    invalid: number
-}
-
-/**
- * The Register class extends `NativeObjectRegister` functionality for this test suite purposes.
- * 
- * ### Warning
- * 
- * > You suppose do not replicate such functionality in your application's code, because it will not
- * > work in the release build.
- */
-class Register {
-    static async findObject(objectId: string, type: NativeObjectType): Promise<boolean> {
-        const r = await NativeObjectRegister.debugCommand('find', { objectId: objectId, objectType: type })
-        if (typeof r === 'boolean') {
-            return r
-        } else {
-            throw new Error('Unexpected result')
-        }
-    }
-
-    static async useObject(objectId: string, type: NativeObjectType): Promise<boolean> {
-        const r = await NativeObjectRegister.debugCommand('use', { objectId: objectId, objectType: type })
-        if (typeof r === 'boolean') {
-            return r
-        } else {
-            throw new Error('Unexpected result')
-        }
-    }
-
-    static async touchObject(objectId: string, type: NativeObjectType): Promise<boolean> {
-        const r = await NativeObjectRegister.debugCommand('touch', { objectId: objectId, objectType: type })
-        if (typeof r === 'boolean') {
-            return r
-        } else {
-            throw new Error('Unexpected result')
-        }
-    }
-
-    static async removeObject(objectId: string, type: NativeObjectType): Promise<boolean> {
-        const r = await NativeObjectRegister.debugCommand('release', { objectId: objectId, objectType: type })
-        if (typeof r === 'boolean') {
-            return r
-        } else {
-            throw new Error('Unexpected result')
-        }
-    }
-
-    static async createObject(data: NativeObjectCmdData): Promise<string> {
-        const r = await NativeObjectRegister.debugCommand('create', data)
-        if (typeof r === 'string') {
-            return r
-        } else {
-            throw new Error('Unexpected result')
-        }
-    }
-
-    static setCleanupPeriod(periodInMs: number): Promise<NativeObjectCmdResult> {
-        return NativeObjectRegister.debugCommand('setPeriod', { cleanupPeriod: periodInMs })
-    }
-
-    static async countObjects(tag: string): Promise<ObjectsCount> {
-        const r = await NativeObjectRegister.debugDump(tag)
-        return { 
-            valid:   r.reduce((prev, item) => prev + (item.isValid ? 1 : 0), 0), 
-            invalid: r.reduce((prev, item) => prev + (item.isValid ? 0 : 1), 0)
-        }
-    }
-}
+import { Register } from "./helpers/NativeObjectRegister";
 
 export class NativeObjectRegisterTests extends TestWithActivation {
 

--- a/testapp/_tests/PowerAuthPassword.test.ts
+++ b/testapp/_tests/PowerAuthPassword.test.ts
@@ -1,0 +1,363 @@
+//
+// Copyright 2022 Wultra s.r.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { PowerAuth, PowerAuthConfiguration, PowerAuthErrorCode, PowerAuthPassword } from "react-native-powerauth-mobile-sdk";
+import { TestSuite, expect } from "../src/testbed";
+import { Register } from "./helpers/NativeObjectRegister";
+import { importPassword } from "./helpers/PasswordHelper";
+
+export class PowerAuthPasswordTests extends TestSuite {
+
+    cleanup = new Array<any>()
+
+    async beforeAll() {
+        await super.beforeAll()
+        // Set very short cleanup period
+        await Register.setCleanupPeriod(100)
+    }
+
+    async afterAll() {
+        await super.afterAll()
+        // Set back the default period
+        await Register.setCleanupPeriod(0)
+    }
+    
+    async beforeEach(): Promise<void> {
+        await super.beforeEach()
+        this.cleanup = new Array<any>()
+    }
+
+    async afterEach(): Promise<void> {
+        await super.afterEach()
+        // Just to be sure, release all allocated objects from the memory
+        for (let i in this.cleanup) {
+            const p = this.cleanup[i]
+            if (p instanceof PowerAuthPassword) {
+                await p.release()
+            } else if (p instanceof PowerAuth) {
+                await p.deconfigure()
+            }
+        }
+    }
+
+    async testAddCharacters() {
+        const p1 = new PowerAuthPassword()
+        const p2 = new PowerAuthPassword()
+        const p3 = await importPassword('0123')
+        const pEmpty = new PowerAuthPassword()
+        this.cleanup.push(p1, p2, p3, pEmpty)
+
+        expect(await p1.isEmpty()).toBe(true)
+        expect(await p2.isEmpty()).toBe(true)
+        expect(await p1.isEqualTo(pEmpty)).toBe(true)
+        expect(await p2.isEqualTo(pEmpty)).toBe(true)
+        expect(await p3.isEqualTo(pEmpty)).toBe(false)
+
+        expect(await p1.addCharacter('0')).toBe(1)
+        expect(await p2.addCharacter(48)).toBe(1)
+        expect(await p1.isEqualTo(pEmpty)).toBe(false)
+        expect(await p2.isEqualTo(pEmpty)).toBe(false)
+        expect(await p1.isEmpty()).toBe(false)
+        expect(await p2.isEmpty()).toBe(false)
+
+        expect(await p1.addCharacter('1')).toBe(2)
+        expect(await p2.addCharacter(49)).toBe(2)
+        expect(await p1.addCharacter('2')).toBe(3)
+        expect(await p2.addCharacter(50)).toBe(3)
+        expect(await p1.addCharacter('3')).toBe(4)
+        expect(await p2.addCharacter(51)).toBe(4)
+
+        await expect(async () => p1.addCharacter(0x110000)).toThrow({errorCode: PowerAuthErrorCode.WRONG_PARAMETER})
+
+        expect(await p1.isEqualTo(p3)).toBe(true)
+        expect(await p2.isEqualTo(p3)).toBe(true)
+        expect(await p1.isEqualTo(p2)).toBe(true)
+        
+        p1.clear()
+        p2.clear()
+        expect(await p1.isEqualTo(pEmpty)).toBe(true)
+        expect(await p2.isEqualTo(pEmpty)).toBe(true)
+    }
+
+    async testRemoveCharacters() {
+        const p1 = await importPassword('Sk💀Ll')
+        const t1 = await importPassword('k💀Ll')
+        const t2 = await importPassword('k💀L')
+        const t3 = await importPassword('kL')
+        const t4 = await importPassword('k')
+        this.cleanup.push(p1, t1, t2, t3, t4)
+
+        await expect(async () => p1.removeCharacterAt(-1)).toThrow({errorCode: PowerAuthErrorCode.WRONG_PARAMETER})
+        await expect(async () => p1.removeCharacterAt(5)).toThrow({errorCode: PowerAuthErrorCode.WRONG_PARAMETER})
+
+        expect(await p1.removeCharacterAt(0)).toBe(4)
+        expect(await p1.isEqualTo(t1)).toBe(true)
+        expect(await p1.removeLastCharacter()).toBe(3)
+        expect(await p1.isEqualTo(t2)).toBe(true)
+        expect(await p1.removeCharacterAt(1)).toBe(2)
+        expect(await p1.isEqualTo(t3)).toBe(true)
+        expect(await p1.removeCharacterAt(1)).toBe(1)
+        expect(await p1.isEqualTo(t4)).toBe(true)
+        expect(await p1.removeCharacterAt(0)).toBe(0)
+        expect(await p1.length()).toBe(0)
+        // Pop last should not fail
+        expect(await p1.removeLastCharacter()).toBe(0)
+
+        await expect(async () => p1.removeCharacterAt(0)).toThrow({errorCode: PowerAuthErrorCode.WRONG_PARAMETER})
+    }
+
+    async testInsertCharacters() {
+        const p1 = new PowerAuthPassword()
+        const p2 = await importPassword('Sk💀ll')
+        this.cleanup.push(p1, p2)
+
+        expect(await p1.insertCharacter('l', 0)).toBe(1)
+        expect(await p1.insertCharacter('l', 1)).toBe(2)
+        expect(await p1.insertCharacter('S', 0)).toBe(3)
+        expect(await p1.insertCharacter('k', 1)).toBe(4)
+        expect(await p1.insertCharacter(0x1F480, 2)).toBe(5)
+
+        await expect(async () => p1.insertCharacter('X', -1)).toThrow({errorCode: PowerAuthErrorCode.WRONG_PARAMETER})
+        await expect(async () => p1.insertCharacter('X', 6)).toThrow({errorCode: PowerAuthErrorCode.WRONG_PARAMETER})
+        await expect(async () => p1.insertCharacter(0x110000, 0)).toThrow({errorCode: PowerAuthErrorCode.WRONG_PARAMETER})
+
+        expect(await p1.isEqualTo(p2)).toBe(true)
+    }
+
+    async testUnicode() {
+        const p1 = await importPassword('★🤣🤫🪘')
+        const p2 = await importPassword('Sk💀ll')
+        const p3 = new PowerAuthPassword()
+        const p4 = new PowerAuthPassword()
+        this.cleanup.push(p1, p2, p3, p4)
+        
+        expect(await p1.length()).toBe(4)
+        expect(await p2.length()).toBe(5)
+
+        await p3.addCharacter('★')
+        await p3.addCharacter('🤣🤫')
+        await p3.addCharacter('🤫')
+        await p3.addCharacter('🪘x')
+
+        expect(await p3.length()).toBe(4)
+
+        await p4.addCharacter(0x2605)
+        await p4.addCharacter(0x1F923)
+        await p4.addCharacter(0x1F92B)
+        await p4.addCharacter(0x1FA98)
+
+        expect(await p4.length()).toBe(4)
+
+        expect(await p3.isEqualTo(p4)).toBe(true)
+        expect(await p3.isEqualTo(p1)).toBe(true)
+        expect(await p4.isEqualTo(p1)).toBe(true)
+    }
+
+    async testAutomaticCleanup() {
+        let p1CleanupCalled = 0
+        let p2CleanupCalled = 0
+        const p1 = new PowerAuthPassword(false, undefined, () => { p1CleanupCalled += 1 }, 100)
+        const p2 = new PowerAuthPassword(false, undefined, () => { p2CleanupCalled += 1 }, 100)
+        this.cleanup.push(p1, p2)
+
+        // Right after construct the identifier is not set
+        const id1AfterCreate = ((p1 as any).passwordObjectId)
+        const id2AfterCreate = ((p2 as any).passwordObjectId)
+        expect(id1AfterCreate).toBeUndefined()
+        expect(id2AfterCreate).toBeUndefined()
+        // We have to call at least some function to create underlying native object
+        expect(await p1.isEmpty()).toBe(true)
+        expect(await p2.length()).toBe(0)
+        // Now identifiers are available, but no cleanup was called
+        const id1AfterAccess = ((p1 as any).passwordObjectId)!
+        const id2AfterAccess = ((p2 as any).passwordObjectId)!
+        expect(id1AfterAccess).toBeDefined()
+        expect(id2AfterAccess).toBeDefined()
+        expect(p1CleanupCalled).toBe(0)
+        expect(p2CleanupCalled).toBe(0)
+
+        // Wait for 50ms
+        await this.sleep(50)
+        // Both passwords should exist now
+        expect(await Register.findObject(id1AfterAccess, 'password')).toBe(true)
+        expect(await Register.findObject(id2AfterAccess, 'password')).toBe(true)
+        // Access 1st password, to extend it's lifetime
+        await p1.addCharacter(48)
+        // Wait for another 50ms, p2 should be released now
+        await this.sleep(50)
+
+        expect(await Register.findObject(id1AfterAccess, 'password')).toBe(true)
+        expect(await Register.findObject(id2AfterAccess, 'password')).toBe(false)
+        // native p2 is no longer valid, but its identifier is still set in JS object
+        expect(((p2 as any).passwordObjectId)).toBeDefined()
+        // Now extend p1 again
+        expect(await p1.isEmpty()).toBe(false)
+        // And access p2 again. The callback function should be called now
+        expect(await p2.isEmpty()).toBe(true)
+        expect(p2CleanupCalled).toBe(1)
+
+        const id2AfterRestore = ((p2 as any).passwordObjectId)!
+        expect(id2AfterRestore).toNotBe(id2AfterAccess)
+        // Now sleep for another 100ms, so both passwords will be released
+        await this.sleep(100)
+        // Touch both objects
+        expect(await p1.isEqualTo(p2)).toBe(true)
+        expect(await p1.isEmpty()).toBe(true)
+        expect(p1CleanupCalled).toBe(1)
+        expect(p2CleanupCalled).toBe(2)
+        expect(((p1 as any).passwordObjectId)).toNotBe(id1AfterAccess)
+        expect(((p2 as any).passwordObjectId)).toNotBe(id2AfterRestore)
+    }
+
+    async testReleaseAfterUse() {
+        let p1CleanupCalled = 0
+        let p2CleanupCalled = 0
+        const p1 = new PowerAuthPassword(true, undefined, () => { p1CleanupCalled += 1 }, 100)
+        const p2 = new PowerAuthPassword(true, undefined, () => { p2CleanupCalled += 1 }, 100)
+        this.cleanup.push(p1, p2)
+
+        await p1.addCharacter(48)
+        expect(await p1.isEmpty()).toBe(false)
+        expect(await p2.isEmpty()).toBe(true)
+        expect(p1CleanupCalled).toBe(0)
+        expect(p2CleanupCalled).toBe(0)
+
+        const id1AfterAccess = ((p1 as any).passwordObjectId)!
+        const id2AfterAccess = ((p2 as any).passwordObjectId)!
+
+        expect(await Register.useObject(id1AfterAccess, 'password')).toBe(true)
+        expect(await Register.useObject(id2AfterAccess, 'password')).toBe(true)
+
+        expect(await p1.isEmpty()).toBe(true)
+        expect(await p2.isEmpty()).toBe(true)
+
+        expect(p1CleanupCalled).toBe(1)
+        expect(p2CleanupCalled).toBe(1)
+
+        expect(await Register.findObject(id1AfterAccess, 'password')).toBe(false)
+        expect(await Register.findObject(id2AfterAccess, 'password')).toBe(false)
+    }
+    
+    async testManualRelease() {
+        let p1CleanupCalled = 0
+        let p2CleanupCalled = 0
+        const p1 = new PowerAuthPassword(false, undefined, () => { p1CleanupCalled += 1 }, 100)
+        const p2 = new PowerAuthPassword(true, undefined, () => { p2CleanupCalled += 1 }, 100)
+        this.cleanup.push(p1, p2)
+
+        // Native objects are no created yet
+        expect(await p1.release()).toBeUndefined()
+        expect(await p2.release()).toBeUndefined()
+
+        expect(p1CleanupCalled).toBe(0)
+        expect(p2CleanupCalled).toBe(0)
+
+        await p1.addCharacter(48)
+        expect(await p1.isEmpty()).toBe(false)
+        expect(await p2.isEmpty()).toBe(true)
+
+        const id1AfterAccess = ((p1 as any).passwordObjectId)!
+        const id2AfterAccess = ((p2 as any).passwordObjectId)!
+        expect(id1AfterAccess).toBeDefined()
+        expect(id2AfterAccess).toBeDefined()
+
+        expect(p1CleanupCalled).toBe(0)
+        expect(p2CleanupCalled).toBe(0)
+
+        // Now manually release passwords
+        expect(await p1.release()).toBeUndefined()
+        expect(await p2.release()).toBeUndefined()
+
+        expect(await Register.findObject(id1AfterAccess, 'password')).toBe(false)
+        expect(await Register.findObject(id2AfterAccess, 'password')).toBe(false)
+
+        expect(p1CleanupCalled).toBe(0)
+        expect(p2CleanupCalled).toBe(0)
+
+        // Instantiate again, this should not call onAutomaticCleanup, because 
+        // release was initiated by application
+        await p1.addCharacter(48)
+        expect(await p1.isEmpty()).toBe(false)
+        expect(await p2.isEmpty()).toBe(true)
+        expect(p1CleanupCalled).toBe(0)
+        expect(p2CleanupCalled).toBe(0)
+
+        // Now release for multiple times, to make sure that function doesn't fail
+        expect(await p1.release()).toBeUndefined()
+        expect(await p2.release()).toBeUndefined()
+        expect(await p1.release()).toBeUndefined()
+        expect(await p2.release()).toBeUndefined()
+    }
+
+    getRandomId(): string {
+        return 'instanceId_' + (Math.random() + 1).toString(36).substring(7)
+    }
+
+    async testGlobalRelease() {
+        // Dummy values for PA configuration
+        const config = new PowerAuthConfiguration('6NgAwrP3iLfbuN2S8vCyEw==', '6N6JAkZhTTmeDoJG0llXhA==', 'BCgc7k0uu5wjYdbRxObMCLr7vDD5JQW//C0kRZSUYlyixAj/fllAx3pbkHZhogTL42EBUbKZeVqtXsw2PE46SJs=', 'http://localhost/wrong')
+
+        // Owner object represents an instance of PowerAuth class that typically owns various object types
+        const powerAuthInstanceId = this.getRandomId()
+        const powerAuth = new PowerAuth(powerAuthInstanceId)
+        this.cleanup.push(powerAuth)
+
+        // We can create passwords even in PA instance is not configured, but every call to password API will fail
+        let p1CleanupCalled = 0
+        let p2CleanupCalled = 0
+        const p1 = powerAuth.createPassword(false, () => p2CleanupCalled += 1)
+        const p2 = powerAuth.createPassword(true, () => p2CleanupCalled += 1)
+        this.cleanup.push(p1, p2)
+        expect((p1 as any).powerAuthInstanceId).toBe(powerAuthInstanceId)
+        expect((p2 as any).powerAuthInstanceId).toBe(powerAuthInstanceId)
+
+        // PA instance is not configured yet, so the underlying password cannot be created.
+        await expect(async () => p1.addCharacter(48)).toThrow({errorCode: PowerAuthErrorCode.INSTANCE_NOT_CONFIGURED })
+        await expect(async () => p2.removeLastCharacter()).toThrow({errorCode: PowerAuthErrorCode.INSTANCE_NOT_CONFIGURED })
+
+        // Configure PA instance
+        await powerAuth.configure(config)
+
+        // Now everything should work as expected
+        await p1.addCharacter(48)
+        expect(await p1.isEmpty()).toBe(false)
+        expect(await p2.isEmpty()).toBe(true)
+        expect(p1CleanupCalled).toBe(0)
+        expect(p2CleanupCalled).toBe(0)
+
+        const id1AfterAccess = ((p1 as any).passwordObjectId)!
+        const id2AfterAccess = ((p2 as any).passwordObjectId)!
+        
+        expect(await Register.findObject(id1AfterAccess, 'password')).toBe(true)
+        expect(await Register.findObject(id2AfterAccess, 'password')).toBe(true)
+
+        // Now deconfigure PA instance
+        await powerAuth.deconfigure()
+        // Both passwords should be released
+        expect(await Register.findObject(id1AfterAccess, 'password')).toBe(false)
+        expect(await Register.findObject(id2AfterAccess, 'password')).toBe(false)
+
+        // Now any access to password leads to the error, because parent object is not in the register
+        await expect(async () => p1.isEmpty()).toThrow({errorCode: PowerAuthErrorCode.INSTANCE_NOT_CONFIGURED })
+        await expect(async () => p2.length()).toThrow({errorCode: PowerAuthErrorCode.INSTANCE_NOT_CONFIGURED })
+
+        // Configure PA instance again
+        await powerAuth.configure(config)
+
+        expect(await p1.isEmpty()).toBe(true)
+        expect(await p2.isEmpty()).toBe(true)
+    }
+}

--- a/testapp/_tests/PowerAuthPassword.test.ts
+++ b/testapp/_tests/PowerAuthPassword.test.ts
@@ -259,8 +259,8 @@ export class PowerAuthPasswordTests extends TestSuite {
         this.cleanup.push(p1, p2)
 
         // Native objects are no created yet
-        expect(await p1.release()).toBeUndefined()
-        expect(await p2.release()).toBeUndefined()
+        await p1.release()
+        await p2.release()
 
         expect(p1CleanupCalled).toBe(0)
         expect(p2CleanupCalled).toBe(0)
@@ -278,8 +278,8 @@ export class PowerAuthPasswordTests extends TestSuite {
         expect(p2CleanupCalled).toBe(0)
 
         // Now manually release passwords
-        expect(await p1.release()).toBeUndefined()
-        expect(await p2.release()).toBeUndefined()
+        await p1.release()
+        await p2.release()
 
         expect(await Register.findObject(id1AfterAccess, 'password')).toBe(false)
         expect(await Register.findObject(id2AfterAccess, 'password')).toBe(false)
@@ -296,10 +296,10 @@ export class PowerAuthPasswordTests extends TestSuite {
         expect(p2CleanupCalled).toBe(0)
 
         // Now release for multiple times, to make sure that function doesn't fail
-        expect(await p1.release()).toBeUndefined()
-        expect(await p2.release()).toBeUndefined()
-        expect(await p1.release()).toBeUndefined()
-        expect(await p2.release()).toBeUndefined()
+        await p1.release()
+        await p2.release()
+        await p1.release()
+        await p2.release()
     }
 
     getRandomId(): string {

--- a/testapp/_tests/PowerAuth_Example.ts
+++ b/testapp/_tests/PowerAuth_Example.ts
@@ -15,6 +15,7 @@
 //
 
 import { PowerAuth, PowerAuthActivation, PowerAuthActivationCodeUtil, PowerAuthActivationState, PowerAuthAuthentication, PowerAuthBiometryConfiguration, PowerAuthClientConfiguration, PowerAuthConfiguration, PowerAuthError, PowerAuthErrorCode } from "react-native-powerauth-mobile-sdk";
+import { importPassword } from "./helpers/PasswordHelper";
 import { TestWithServer } from "./helpers/TestWithServer";
 
 /**
@@ -146,7 +147,13 @@ export class PowerAuth_Example extends TestWithServer {
         }
 
         // Now you can instruct user to enter his PIN or password
-        const password = "123456"
+        const password = this.powerAuth.createPassword()
+        await password.addCharacter('1')
+        await password.addCharacter('2')
+        await password.addCharacter('3')
+        await password.addCharacter('5')
+        await password.addCharacter('7')
+        await password.addCharacter('9')
         const commitAuthentication = new PowerAuthAuthentication()
         commitAuthentication.userPassword = password
         commitAuthentication.useBiometry = true
@@ -177,7 +184,7 @@ export class PowerAuth_Example extends TestWithServer {
         }
 
         // Now you're ready to sign some HTTP requests... The most simple way is to verify the password
-        await this.powerAuth.validatePassword(password)
+        await this.powerAuth.validatePassword(await importPassword('123579'))
 
         try {
             await this.powerAuth.validatePassword('badpassword')
@@ -198,7 +205,7 @@ export class PowerAuth_Example extends TestWithServer {
         this.reportInfo(`You entered a bad password. You have ${status.remainingAttempts} from ${status.maxFailCount} attempts left`)
 
         // So try again...
-        await this.powerAuth.validatePassword(password)
+        await this.powerAuth.validatePassword(await importPassword('123579'))
 
         // Now remainingAttemtps is back to 5
         status = await this.powerAuth.fetchActivationStatus()
@@ -229,6 +236,9 @@ export class PowerAuth_Example extends TestWithServer {
 
         // Now everything should be in its initial state
         await this.printActivationState('After cleanup')
+
+        // If PA instance is no longer needed, then just deconfigure it
+        await this.powerAuth.deconfigure()
     }
 
     async printActivationState(stage: string) {

--- a/testapp/_tests/PowerAuth_Password.test.ts
+++ b/testapp/_tests/PowerAuth_Password.test.ts
@@ -14,8 +14,9 @@
 // limitations under the License.
 //
 
-import { PowerAuthErrorCode } from "react-native-powerauth-mobile-sdk";
+import { PowerAuthAuthentication, PowerAuthErrorCode } from "react-native-powerauth-mobile-sdk";
 import { expect } from "../src/testbed";
+import { importPassword } from "./helpers/PasswordHelper";
 import { TestWithActivation } from "./helpers/TestWithActivation";
 
 export class PowerAuth_PasswordTests extends TestWithActivation {
@@ -26,6 +27,15 @@ export class PowerAuth_PasswordTests extends TestWithActivation {
         await expect(async () => this.sdk.validatePassword(this.credentials.invalidPassword)).toThrow({errorCode: PowerAuthErrorCode.AUTHENTICATION_ERROR})
         // TODO: wrong param
         await expect(async () => this.sdk.validatePassword('12')).toThrow({errorCode: PowerAuthErrorCode.SIGNATURE_ERROR})
+    }
+
+    async testValidateSecurePassword() {
+        // Valid password
+        await this.sdk.validatePassword(await importPassword(this.credentials.validPassword))
+        // Wrong password
+        await expect(async () => this.sdk.validatePassword(await importPassword(this.credentials.invalidPassword))).toThrow({errorCode: PowerAuthErrorCode.AUTHENTICATION_ERROR})
+        // TODO: wrong param
+        await expect(async () => this.sdk.validatePassword(await importPassword('12'))).toThrow({errorCode: PowerAuthErrorCode.SIGNATURE_ERROR})
     }
 
     async testChangePassword() {
@@ -44,6 +54,22 @@ export class PowerAuth_PasswordTests extends TestWithActivation {
         await expect(async () => this.sdk.changePassword('12', this.credentials.validPassword)).toThrow({errorCode: PowerAuthErrorCode.SIGNATURE_ERROR})
     }
 
+    async testChangeSecurePassword() {
+        await this.sdk.changePassword(await importPassword(this.credentials.validPassword), await importPassword(this.credentials.invalidPassword))
+        await this.sdk.validatePassword(await importPassword(this.credentials.invalidPassword))
+        await expect(async () => this.sdk.validatePassword(await importPassword(this.credentials.validPassword))).toThrow({errorCode: PowerAuthErrorCode.AUTHENTICATION_ERROR})
+
+        // back to original
+        await this.sdk.changePassword(await importPassword(this.credentials.invalidPassword), await importPassword(this.credentials.validPassword))
+        await this.sdk.validatePassword(await importPassword(this.credentials.validPassword))
+        await expect(async () => this.sdk.validatePassword(this.credentials.invalidPassword)).toThrow({errorCode: PowerAuthErrorCode.AUTHENTICATION_ERROR})
+
+        // TODO: INVALID_ACTIVATION_STATE, WRONG_PARAM expected
+        // await expect(async () => this.sdk.changePassword(this.credentials.validPassword, '12')).toThrow({errorCode: PowerAuthErrorCode.AUTHENTICATION_ERROR})
+        // TODO: WRONG_PARAM expected
+        await expect(async () => this.sdk.changePassword(await importPassword('12'), this.credentials.validPassword)).toThrow({errorCode: PowerAuthErrorCode.SIGNATURE_ERROR})
+    }
+
     async testChangePasswordUnsafe() {
         await this.sdk.unsafeChangePassword(this.credentials.validPassword, this.credentials.invalidPassword)
         await this.sdk.validatePassword(this.credentials.invalidPassword)
@@ -54,5 +80,75 @@ export class PowerAuth_PasswordTests extends TestWithActivation {
         //await expect(async () => this.sdk.changePassword('12', this.credentials.validPassword)).toThrow({errorCode: PowerAuthErrorCode.INVALID_ACTIVATION_STATE})
         // TODO: WRONG_PARAM expected
         //await expect(async () => this.sdk.changePassword(this.credentials.validPassword, '12')).toThrow({errorCode: PowerAuthErrorCode.INVALID_ACTIVATION_STATE})
+    }
+
+    async testChangeSecurePasswordUnsafe() {
+        await this.sdk.unsafeChangePassword(await importPassword(this.credentials.validPassword), await importPassword(this.credentials.invalidPassword))
+        await this.sdk.validatePassword(await importPassword(this.credentials.invalidPassword))
+        await this.sdk.unsafeChangePassword(await importPassword(this.credentials.invalidPassword), await importPassword(this.credentials.validPassword))
+        await this.sdk.validatePassword(await importPassword(this.credentials.validPassword))
+
+        // TODO: WRONG_PARAM expected
+        //await expect(async () => this.sdk.changePassword('12', this.credentials.validPassword)).toThrow({errorCode: PowerAuthErrorCode.INVALID_ACTIVATION_STATE})
+        // TODO: WRONG_PARAM expected
+        //await expect(async () => this.sdk.changePassword(this.credentials.validPassword, '12')).toThrow({errorCode: PowerAuthErrorCode.INVALID_ACTIVATION_STATE})
+    }
+
+    async testReusePasswordObject() {
+        const pValid = await importPassword(this.credentials.validPassword, false, this.sdk)
+        const pInvalid = await importPassword(this.credentials.invalidPassword, false, this.sdk)
+
+        await this.sdk.unsafeChangePassword(pValid, pInvalid)
+        await this.sdk.validatePassword(pInvalid)
+        await this.sdk.unsafeChangePassword(pInvalid, pValid)
+        await this.sdk.validatePassword(pValid)
+    }
+
+    async testReuseUsedPasswordObject() {
+        const pValid = await importPassword(this.credentials.validPassword, true, this.sdk)
+        const pInvalid = await importPassword(this.credentials.invalidPassword, true, this.sdk)
+
+        await this.sdk.unsafeChangePassword(pValid, pInvalid)
+        await expect(async () => await this.sdk.validatePassword(pInvalid)).toThrow({errorCode: PowerAuthErrorCode.INVALID_NATIVE_OBJECT})
+    }
+
+    async testReusePasswordObjectInAuth() {
+        const pValid = await importPassword(this.credentials.validPassword, false, this.sdk)
+        const pInvalid = await importPassword(this.credentials.invalidPassword, false, this.sdk)
+        const signatureHelper = this.helper.signatureHelper
+        
+        const validAuth = new PowerAuthAuthentication()
+        validAuth.userPassword = pValid
+        const invalidAuth = new PowerAuthAuthentication()
+        invalidAuth.userPassword = pInvalid
+
+        let header = await this.sdk.requestSignature(validAuth, 'POST', '/some/uriId', '{}')
+        expect(await signatureHelper.verifyOnlineSignature('POST', '/some/uriId', '{}', header.value)).toBe(true)
+        header = await this.sdk.requestSignature(validAuth, 'POST', '/some/uriId', '{}')
+        expect(await signatureHelper.verifyOnlineSignature('POST', '/some/uriId', '{}', header.value)).toBe(true)
+        
+        header = await this.sdk.requestSignature(invalidAuth, 'POST', '/some/uriId', '{}')
+        expect(await signatureHelper.verifyOnlineSignature('POST', '/some/uriId', '{}', header.value)).toBe(false)
+        header = await this.sdk.requestSignature(invalidAuth, 'POST', '/some/uriId', '{}')
+        expect(await signatureHelper.verifyOnlineSignature('POST', '/some/uriId', '{}', header.value)).toBe(false)
+    }
+
+    async testReuseUsedPasswordObjectInAuth() {
+        const pValid = await importPassword(this.credentials.validPassword, true, this.sdk)
+        const pInvalid = await importPassword(this.credentials.invalidPassword, true, this.sdk)
+        const signatureHelper = this.helper.signatureHelper
+        
+        const validAuth = new PowerAuthAuthentication()
+        validAuth.userPassword = pValid
+        const invalidAuth = new PowerAuthAuthentication()
+        invalidAuth.userPassword = pInvalid
+
+        let header = await this.sdk.requestSignature(validAuth, 'POST', '/some/uriId', '{}')
+        expect(await signatureHelper.verifyOnlineSignature('POST', '/some/uriId', '{}', header.value)).toBe(true)
+        await expect(async () => this.sdk.requestSignature(validAuth, 'POST', '/some/uriId', '{}')).toThrow({ errorCode: PowerAuthErrorCode.INVALID_NATIVE_OBJECT })
+
+        header = await this.sdk.requestSignature(invalidAuth, 'POST', '/some/uriId', '{}')
+        expect(await signatureHelper.verifyOnlineSignature('POST', '/some/uriId', '{}', header.value)).toBe(false)
+        await expect(async () => this.sdk.requestSignature(invalidAuth, 'POST', '/some/uriId', '{}')).toThrow({ errorCode: PowerAuthErrorCode.INVALID_NATIVE_OBJECT })
     }
 }

--- a/testapp/_tests/helpers/NativeObjectRegister.ts
+++ b/testapp/_tests/helpers/NativeObjectRegister.ts
@@ -1,0 +1,89 @@
+//
+// Copyright 2022 Wultra s.r.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { NativeObjectCmdData, NativeObjectCmdResult, NativeObjectRegister, NativeObjectType } from "react-native-powerauth-mobile-sdk"
+
+export interface ObjectsCount {
+    valid: number
+    invalid: number
+}
+
+/**
+ * The Register class extends `NativeObjectRegister` functionality for this test suite purposes.
+ * 
+ * ### Warning
+ * 
+ * > You suppose do not replicate such functionality in your application's code, because it will not
+ * > work in the release build.
+ */
+export class Register {
+    static async findObject(objectId: string, type: NativeObjectType): Promise<boolean> {
+        const r = await NativeObjectRegister.debugCommand('find', { objectId: objectId, objectType: type })
+        if (typeof r === 'boolean') {
+            return r
+        } else {
+            throw new Error('Unexpected result')
+        }
+    }
+
+    static async useObject(objectId: string, type: NativeObjectType): Promise<boolean> {
+        const r = await NativeObjectRegister.debugCommand('use', { objectId: objectId, objectType: type })
+        if (typeof r === 'boolean') {
+            return r
+        } else {
+            throw new Error('Unexpected result')
+        }
+    }
+
+    static async touchObject(objectId: string, type: NativeObjectType): Promise<boolean> {
+        const r = await NativeObjectRegister.debugCommand('touch', { objectId: objectId, objectType: type })
+        if (typeof r === 'boolean') {
+            return r
+        } else {
+            throw new Error('Unexpected result')
+        }
+    }
+
+    static async removeObject(objectId: string, type: NativeObjectType): Promise<boolean> {
+        const r = await NativeObjectRegister.debugCommand('release', { objectId: objectId, objectType: type })
+        if (typeof r === 'boolean') {
+            return r
+        } else {
+            throw new Error('Unexpected result')
+        }
+    }
+
+    static async createObject(data: NativeObjectCmdData): Promise<string> {
+        const r = await NativeObjectRegister.debugCommand('create', data)
+        if (typeof r === 'string') {
+            return r
+        } else {
+            throw new Error('Unexpected result')
+        }
+    }
+
+    static setCleanupPeriod(periodInMs: number): Promise<NativeObjectCmdResult> {
+        return NativeObjectRegister.debugCommand('setPeriod', { cleanupPeriod: periodInMs })
+    }
+
+    static async countObjects(tag: string): Promise<ObjectsCount> {
+        const r = await NativeObjectRegister.debugDump(tag)
+        return { 
+            valid:   r.reduce((prev, item) => prev + (item.isValid ? 1 : 0), 0), 
+            invalid: r.reduce((prev, item) => prev + (item.isValid ? 0 : 1), 0)
+        }
+    }
+}

--- a/testapp/_tests/helpers/PasswordHelper.ts
+++ b/testapp/_tests/helpers/PasswordHelper.ts
@@ -1,0 +1,42 @@
+//
+// Copyright 2022 Wultra s.r.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { PowerAuth, PowerAuthPassword } from "react-native-powerauth-mobile-sdk";
+
+/**
+ * Function creates PowerAuthPassword object and imports provided passphrase from the string. 
+ * In the regular app, you let user to type the password character by character, so don't use such
+ * function in your application.
+ * @param password String with password to import.
+ * @param destroyOnUse Password will be destroyed on use.
+ * @param owner If provided, then the password will be associated with given PowerAuth instance.
+ * @param pass If provided, then the string will be imported to this object.
+ * @returns PowerAuthPassword with imported passphrase.
+ */
+export async function importPassword(password: string, destroyOnUse: boolean = true, owner: PowerAuth | undefined = undefined, pass: PowerAuthPassword | undefined = undefined): Promise<PowerAuthPassword> {
+    const p = pass ?? owner?.createPassword(destroyOnUse) ?? new PowerAuthPassword(destroyOnUse)
+    let pos = 0;
+    while (pos < password.length) {
+        const cp = password.codePointAt(pos)
+        if (cp) {
+            await p.addCharacter(cp)
+            pos += String.fromCodePoint(cp).length    
+        } else {
+            throw new Error('Failed to extract codepoint')
+        }
+    }
+    return p
+}

--- a/testapp/ios/Podfile
+++ b/testapp/ios/Podfile
@@ -24,7 +24,7 @@ target 'testapp' do
   # At first, remove "Pods" and "Podfile.lock", 
   #   then uncomment the following line and setup proper branch with unpublished code,
   #   and finally run "pod install".
-  pod 'PowerAuth2', :git => 'https://github.com/wultra/powerauth-mobile-sdk.git', :branch => 'develop', :submodules => true
+  #pod 'PowerAuth2', :git => 'https://github.com/wultra/powerauth-mobile-sdk.git', :branch => 'develop', :submodules => true
 
   # Enables Flipper.
   #

--- a/testapp/ios/Podfile.lock
+++ b/testapp/ios/Podfile.lock
@@ -76,9 +76,9 @@ PODS:
   - hermes-engine (0.11.0)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
-  - PowerAuth2 (1.7.3):
-    - PowerAuthCore (~> 1.7.3)
-  - PowerAuthCore (1.7.3)
+  - PowerAuth2 (1.7.4):
+    - PowerAuthCore (~> 1.7.4)
+  - PowerAuthCore (1.7.4)
   - RCT-Folly (2021.06.28.00-v2):
     - boost
     - DoubleConversion
@@ -304,7 +304,7 @@ PODS:
   - React-logger (0.68.3):
     - glog
   - react-native-powerauth-mobile-sdk (2.3.0):
-    - PowerAuth2 (~> 1.7.3)
+    - PowerAuth2 (~> 1.7.4)
     - React
   - React-perflogger (0.68.3)
   - React-RCTActionSheet (0.68.3):
@@ -406,7 +406,6 @@ DEPENDENCIES:
   - hermes-engine (~> 0.11.0)
   - libevent (~> 2.1.12)
   - OpenSSL-Universal (= 1.1.1100)
-  - PowerAuth2 (from `https://github.com/wultra/powerauth-mobile-sdk.git`, branch `develop`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
   - RCTTypeSafety (from `../node_modules/react-native/Libraries/TypeSafety`)
@@ -454,6 +453,7 @@ SPEC REPOS:
     - hermes-engine
     - libevent
     - OpenSSL-Universal
+    - PowerAuth2
     - PowerAuthCore
     - SocketRocket
     - YogaKit
@@ -469,10 +469,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/React/FBReactNativeSpec"
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
-  PowerAuth2:
-    :branch: develop
-    :git: https://github.com/wultra/powerauth-mobile-sdk.git
-    :submodules: true
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTRequired:
@@ -530,12 +526,6 @@ EXTERNAL SOURCES:
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
-CHECKOUT OPTIONS:
-  PowerAuth2:
-    :commit: 74f9907b1329bc3e2f9612f1621e90a30b4aea5a
-    :git: https://github.com/wultra/powerauth-mobile-sdk.git
-    :submodules: true
-
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
@@ -556,8 +546,8 @@ SPEC CHECKSUMS:
   hermes-engine: 84e3af1ea01dd7351ac5d8689cbbea1f9903ffc3
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  PowerAuth2: d4d330c9b37dedc7e9645db02ea5a32889578b9e
-  PowerAuthCore: daeed9d22fce70cf1dfbabbff7a87837dada7e2d
+  PowerAuth2: c597eecdb348b231a024a527bf49237573819448
+  PowerAuthCore: d7e5e8cb9307da8033c1d41694cb5cbb35ec332a
   RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
   RCTRequired: b8caca023d386d43740dfb94c2cf68f695fa5e77
   RCTTypeSafety: ec44ea1d6ad1e5cd6447b22159ff40c2ebbd23b1
@@ -572,7 +562,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: a5043e9e1e1bd13b80b58b228c6901b3721a4f54
   React-jsinspector: 86e89b9f135787a2e8eb74b3fc00ec61e9a80ae1
   React-logger: f790bd10f86b38012e108fb4b564023602702270
-  react-native-powerauth-mobile-sdk: 56dc5103df41fee4cee13aa4cc9a4ae2e254d547
+  react-native-powerauth-mobile-sdk: 662c6a4308f1b0df87450e4a0bc9123910a600a1
   React-perflogger: fa15d1d29ff7557ee25ea48f7f59e65896fb3215
   React-RCTActionSheet: e83515333352a3cc19c146e3c7a63a8a9269da8f
   React-RCTAnimation: 8032daa2846e3db7ac28c4c5a207d0bfb5e1e3ad
@@ -589,6 +579,6 @@ SPEC CHECKSUMS:
   Yoga: 2f6a78c58dcc2963bd8e34d96a4246d9dff2e3a7
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 2244a08d672f48d50b66820cd29268989b696fd2
+PODFILE CHECKSUM: 798ade193b192739c56fa9685aae4ab878bc665b
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
This PR adds secure password implementation. The developers can now use `PowerAuthPassword` object as a string replacement to provide user credentials in more secure way.

This PR can be reviewed in per-commit basis. First commit brings iOS + JS implementation and 2nd is for Android.