### PR TITLE
PowerAuthAuthentication improvements and bugfixes

### DIFF
--- a/docs/Biometry-Setup.md
+++ b/docs/Biometry-Setup.md
@@ -73,7 +73,7 @@ const result =  await powerAuth.removeBiometryFactor();
 
 ## Fetch Biometry Credentials In Advance
 
-You can acquire biometry credentials in advance in case that business processes require computing two or more different PowerAuth biometry signatures in one interaction with the user. To achieve this, the application must acquire the custom-created `PowerAuthAuthentication` object first and then use it for the required signature calculations. It's recommended to keep this instance referenced only for a limited time, required for all future signature calculations.
+You can acquire biometry credentials in advance in case that business processes require computing two or more different PowerAuth biometry signatures in one interaction with the user. To achieve this, the application must acquire the custom-created `PowerAuthAuthentication` object first and then use it for the required signature calculations. It's recommended to keep this instance referenced only for a limited time, required for all future signature calculations. If you don't reuse the instance within the 10 seconds of expiration period, then the biometry key is released from the memory and the biometric authentication is displayed again.
 
 Be aware, that you must not execute the next HTTP request signed with the same credentials when the previous one fails with the 401 HTTP status code. If you do, then you risk blocking the user's activation on the server.
 

--- a/docs/Version-2.3.md
+++ b/docs/Version-2.3.md
@@ -66,6 +66,10 @@ auth = PowerAuthAuthentication.commitWithPasswordAndBiometry("1234", {
 });
 ```
 
+<!-- begin box warning -->
+Be aware that you should always create new `PowerAuthAuthentication` object for each authentication attempt.
+<!-- end -->
+
 ## Changes in `PowerAuthToken`
 
 The `PowerAuthToken` interface no longer contains `isValid` and `canGenerateHeader` properties. Such properties were always set to `true`.
@@ -73,8 +77,18 @@ The `PowerAuthToken` interface no longer contains `isValid` and `canGenerateHead
 
 ## Changes in Grouped biometric authentication
 
-The reusable authentication created with `PowerAuth.groupedBiometricAuthentication()` has now a limited lifetime. The expiration time is set to 10 seconds from the last reusable authentication use. The result is that once the previously acquired biometry key is expired, then the biometry dialog is displayed for one more time. For example, if you're calculating signature for two requests and first take more than 10 seconds to execute, then the biometric authentication is displayed again. 
+The reusable authentication created with `PowerAuth.groupedBiometricAuthentication()` has now a limited lifetime. The expiration time is set to 10 seconds from the last reusable authentication use. The result is that once the previously acquired biometry key is expired, then the biometry dialog is displayed for one more time. For example, if you're calculating signature for two requests and first take more than 10 seconds to execute, then the biometric authentication is displayed again.
 
 ## New `PowerAuthPassword` object
 
 If your application's using PIN for users' knowledge factor then you can improve your application's runtime security by adopting new `PowerAuthPassword` object. You can read more details in [Working with passwords securely](Secure-Password.md) chapter.
+
+## Changes in `PowerAuthErrorCode`
+
+- `PowerAuthErrorCode.BIOMETRY_FALLBACK`, reported on iOS, when user cancel the biometric dialog with the fallback button.
+- `PowerAuthErrorCode.INVALID_NATIVE_OBJECT`, reported when native object bridged to JavaScript is no longer valid. This error can be returned when you for example re-use `PowerAuthAuthentication` configured for biometry.
+- `PowerAuthErrorCode.BIOMETRY_NOT_CONFIGURED` is reported when you try to use biometric authentication but the `PowerAuth` instance has no biometry key configured.
+- `PowerAuthErrorCode.BIOMETRY_NOT_ENROLLED` is reported when there's not enrolled biometry on the device.
+- `PowerAuthErrorCode.PASSWORD_NOT_SET` is now `deprecated` and is never returned from the SDK. You can use `WRONG_PARAM` code as a replacement.
+
+Be aware, that `BIOMETRY_*` error codes are now fully supported on both platforms.

--- a/src/PowerAuth.ts
+++ b/src/PowerAuth.ts
@@ -32,6 +32,7 @@ import { NativeWrapper } from "./internal/NativeWrapper";
 import { AuthResolver } from "./internal/AuthResolver";
 import { PasswordType, PowerAuthPassword } from './model/PowerAuthPassword';
 import { PowerAuthActivationCodeUtil } from './PowerAuthActivationCodeUtil';
+import { RawAuthentication } from './internal/NativeTypes';
 
 /**
  * Class used for the main interaction with the PowerAuth SDK components.
@@ -489,7 +490,7 @@ export class PowerAuth {
             throw new PowerAuthError(undefined, "Authentication object is not configured for biometric factor", PowerAuthErrorCode.WRONG_PARAMETER);
         }
         try {
-            const reusable = await this.authenticate(authentication, true);
+            const reusable = await this.authResolver.resolve(authentication, true);
             try {
                 // integrator defined chain of authorization calls with reusable authentication
                 await groupedAuthenticationCalls(reusable);
@@ -517,11 +518,10 @@ export class PowerAuth {
      * Method will process `PowerAuthAuthentication` object are will return object according to the platform.
      * 
      * @param authentication authentication configuration
-     * @param makeReusable if the object should be forced to be reusable
      * @returns configured authorization object
      */
-    private authenticate(authentication: PowerAuthAuthentication, makeReusable: boolean = false): Promise<PowerAuthAuthentication> {
-        return this.authResolver.resolve(authentication, makeReusable)
+    private async authenticate(authentication: PowerAuthAuthentication): Promise<RawAuthentication> {
+        return (await this.authResolver.resolve(authentication, false)).toRawAuthentication()
     }
 
     private authResolver: AuthResolver

--- a/src/internal/NativeObject.ts
+++ b/src/internal/NativeObject.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Wultra s.r.o.
+ * Copyright 2022 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/internal/NativePassphraseMeter.ts
+++ b/src/internal/NativePassphraseMeter.ts
@@ -15,8 +15,8 @@
  */
 
 import { NativeModules } from "react-native"
-import { PinTestResult, RawPassword } from '../index'
-
+import { PinTestResult } from '../index'
+import { RawPassword } from './NativeTypes';
 /**
  * Password interface implemented in the native code.
  */

--- a/src/internal/NativePassword.ts
+++ b/src/internal/NativePassword.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Wultra s.r.o.
+ * Copyright 2022 Wultra s.r.o.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,14 +71,14 @@ export interface PowerAuthPasswordIfc {
     insertCharacter(objectId: string, character: number, position: number): Promise<number>
 
     /**
-     * Remove character 
+     * Remove character at given position.
      * @param objectId Underlying object identifier.
      * @param position 
      */
     removeCharacter(objectId: string, position: number): Promise<number>
     
     /**
-     * 
+     * Remove last character.
      * @param objectId Underlying object identifier.
      */
     removeLastCharacter(objectId: string): Promise<number>

--- a/src/internal/NativeTypes.ts
+++ b/src/internal/NativeTypes.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PasswordType, PowerAuthBiometricPrompt } from '../index'
+
+/**
+ * Object representing a simple native password identifier wrapped in the object.
+ * We need this auxiliary object due to a problematic call to passphrase meter.
+ */
+ export interface RawPassword {
+    /**
+     * Native password's identifier.
+     */
+    passwordObjectId?: string
+}
+
+/**
+ * Object representing a data pased to native methods requiring PowerAuthAuthentication
+ * on imput. The `RawAuthentication` must be be created from `PowerAuthAuthentication`
+ * instance.
+ */
+export interface RawAuthentication {
+    readonly password?: string | RawPassword
+    readonly biometricPrompt?: PowerAuthBiometricPrompt    
+    readonly isCommit?: boolean
+    readonly isBiometry: boolean
+    isReusable: boolean
+    biometryKeyId?: string    
+}

--- a/src/model/PowerAuthPassword.ts
+++ b/src/model/PowerAuthPassword.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { PinTestResult, PowerAuthError, PowerAuthErrorCode, PowerAuthPassphraseMeter } from "../index"
+import { PinTestResult, PowerAuthError, PowerAuthErrorCode } from "../index"
 import { NativePassphraseMeter } from "../internal/NativePassphraseMeter"
 import { NativePassword } from "../internal/NativePassword"
+import { RawPassword } from "../internal/NativeTypes"
 import { NativeWrapper } from "../internal/NativeWrapper"
 
 
@@ -221,10 +222,10 @@ export class PowerAuthPassword {
 
     /**
      * Convert this password object into RawPassword object that can be passed safely to a native call.
-     * @returns RawPassword object.
+     * @returns Frozen RawPassword object.
      */
     toRawPassword(): Promise<RawPassword> {
-        return this.withObjectId(id => Promise.resolve({ passwordObjectId: id }))
+        return this.withObjectId(id => Promise.resolve(Object.freeze({ passwordObjectId: id })))
     }
 
     /**
@@ -248,17 +249,6 @@ export class PowerAuthPassword {
      * Underlying native object's identifier.
      */
     private passwordObjectId?: string
-}
-
-/**
- * Object representing a simple native password identifier wrapped in the object.
- * We need this auxiliary object due to a problematic call to passphrase meter.
- */
-export interface RawPassword {
-    /**
-     * Native password's identifier.
-     */
-    passwordObjectId?: string
 }
 
 /**

--- a/testapp/_tests/testbed/CustomInteraction.ts
+++ b/testapp/_tests/testbed/CustomInteraction.ts
@@ -18,7 +18,7 @@ import { TestContext, UserInteraction, UserPromptDuration } from "../../src/test
 
 export interface PromptWithDuration {
     prompt: string
-    duration: UserPromptDuration
+    duration: UserPromptDuration | "CUSTOM"
 }
 
 export class CustomInteraction implements UserInteraction {
@@ -28,7 +28,13 @@ export class CustomInteraction implements UserInteraction {
         this.promptList = []
     }
 
-    async showPrompt(context: TestContext, message: string, duration: UserPromptDuration): Promise<void> {
+    showPrompt(context: TestContext, message: string, duration: UserPromptDuration): Promise<void> {
         this.promptList.push({prompt: message, duration: duration})
+        return Promise.resolve()
+    }
+
+    sleepWithProgress(context: TestContext, durationMs: number): Promise<void> {
+        this.promptList.push({prompt: `Sleep for ${durationMs} ms`, duration: "CUSTOM" })
+        return Promise.resolve()
     }
 }

--- a/testapp/src/testbed/TestInteraction.ts
+++ b/testapp/src/testbed/TestInteraction.ts
@@ -24,6 +24,7 @@ export enum UserPromptDuration {
 
 export interface UserInteraction {
     showPrompt(context: TestContext, message: string, duration: UserPromptDuration): Promise<void>
+    sleepWithProgress(context: TestContext, durationMs: number): Promise<void>
 }
 
 export interface TestInteraction extends UserInteraction {

--- a/testapp/src/testbed/TestSuite.ts
+++ b/testapp/src/testbed/TestSuite.ts
@@ -166,6 +166,15 @@ export class TestSuite {
     }
 
     /**
+     * Show prompt to the user.
+     * @param duration How long will function sleep, in milliseconds.
+     */
+    sleepWithProgress(duration: number): Promise<void> {
+        this.debugInfo(`Going to sleep for ${duration} ms`)
+        return this.interaction.sleepWithProgress(this.context, duration)
+    }
+
+    /**
      * Report debug information from the test. The information is reported only if `printInfoMessages` is `true`.
      * @param message Information to report.
      */


### PR DESCRIPTION
Fix #145 `PowerAuthAuthentication` is no longer frozen after native call
Fix #142 Reusable  `PowerAuthAuthentication` keeps its reusable functionality
Added missing topics to migration guide
Now it's possible to cancel pending tests in `testapp`