### PR TITLE
Added support for iOS activation data sharing config

### DIFF
--- a/android/src/main/java/com/wultra/android/powerauth/reactnative/PowerAuthModule.java
+++ b/android/src/main/java/com/wultra/android/powerauth/reactnative/PowerAuthModule.java
@@ -96,7 +96,7 @@ public class PowerAuthModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void configure(final String instanceId, final ReadableMap configuration, final ReadableMap clientConfiguration, final ReadableMap biometryConfiguration, final ReadableMap keychainConfiguration, final Promise promise) {
+    public void configure(final String instanceId, final ReadableMap configuration, final ReadableMap clientConfiguration, final ReadableMap biometryConfiguration, final ReadableMap keychainConfiguration, final ReadableMap sharingConfiguration, Promise promise) {
         try {
             boolean result = registerPowerAuthInstance(instanceId, () -> {
                 // Create configurations from maps
@@ -286,6 +286,12 @@ public class PowerAuthModule extends ReactContextBaseJavaModule {
                 promise.resolve(sdk.getActivationFingerprint());
             }
         });
+    }
+
+    @ReactMethod
+    public void getExternalPendingOperation(String instanceId, final Promise promise) {
+        // Not supported on Android
+        promise.resolve(null);
     }
 
     @ReactMethod

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -75,7 +75,7 @@ In case that you need an advanced configuration, then you can import and use the
   - `appIdentifier`- defines unique application identifier. This identifier helps you to determine which application currently holds the lock on activation data in a special operations.
   - `keychainAccessGroup` - defines keychain access group name used by the PowerAuthSDK keychain instances.
   - `sharedMemoryIdentifier` - defines optional identifier of memory shared between the applications in app group. If identifier is not provided then PowerAuthSDK calculate unique identifier based on `PowerAuth.instanceId`.
-  - If you're not familiar with sharing data between iOS applications, or app extensions, then please refer the native PowerAuht mobile SDK documentation, where this topic is explained in more detail. 
+  - If you're not familiar with sharing data between iOS applications, or app extensions, then please refer the native PowerAuth mobile SDK documentation, where this topic is explained in more detail. 
 
 
 > Note 1: Setting `authenticateOnBiometricKeySetup` parameter to `true` leads to use symmetric AES cipher on the background so both configuration and usage of biometric key require the biometric authentication. If set to `false`, then RSA cipher is used and only the usage of biometric key require the biometric authentication. This is due to fact, that RSA cipher can encrypt data with using it's public key available immediate after the key-pair is created in Android KeyStore.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -70,6 +70,14 @@ In case that you need an advanced configuration, then you can import and use the
   - `userDefaultsSuiteName` - iOS specific, defines suite name used by the `UserDefaults` that check for Keychain data presence. This is useful in situations, when your application is sharing data with another application or application's extension from the same vendor. The default value is `null`. See note<sup>2</sup> below.
   - `minimalRequiredKeychainProtection` - Android specific, defines minimal required keychain protection level that must be supported on the current device. The default value is `PowerAuthKeychainProtection.NONE`. See note<sup>3</sup> below.
 
+- `PowerAuthSharingConfiguration` class or `PowerAuthSharingConfigurationType` interface - to configure an activation data sharing on iOS platform. You can alter the following parameters:
+  - `appGroup` - defines name of app group that allows you sharing data between multiple applications. Be aware that the value  overrides `accessGroupName` property if it's provided in `PowerAuthKeychainConfiguration`.
+  - `appIdentifier`- defines unique application identifier. This identifier helps you to determine which application currently holds the lock on activation data in a special operations.
+  - `keychainAccessGroup` - defines keychain access group name used by the PowerAuthSDK keychain instances.
+  - `sharedMemoryIdentifier` - defines optional identifier of memory shared between the applications in app group. If identifier is not provided then PowerAuthSDK calculate unique identifier based on `PowerAuth.instanceId`.
+  - If you're not familiar with sharing data between iOS applications, or app extensions, then please refer the native PowerAuht mobile SDK documentation, where this topic is explained in more detail. 
+
+
 > Note 1: Setting `authenticateOnBiometricKeySetup` parameter to `true` leads to use symmetric AES cipher on the background so both configuration and usage of biometric key require the biometric authentication. If set to `false`, then RSA cipher is used and only the usage of biometric key require the biometric authentication. This is due to fact, that RSA cipher can encrypt data with using it's public key available immediate after the key-pair is created in Android KeyStore.
 
 > Note 2: You're responsible to migrate the keychain and `UserDefaults` data from non-shared storage to the shared one, before you configure the first `PowerAuth` instance. This is quite difficult to do in JavaScript, so it's recommended to do not alter `PowerAuthKeychainConfiguration` once your application is already shipped in AppStore.
@@ -100,7 +108,15 @@ export default class AppMyApplication extends Component {
               const clientConfiguration = { enableUnsecureTraffic: false };
               const biometryConfiguration = { linkItemsToCurrentSet: true };
               const keychainConfiguration = { minimalRequiredKeychainProtection: PowerAuthKeychainProtection.SOFTWARE };
-              await this.powerAuth.configure(configuration, clientConfiguration, biometryConfiguration, keychainConfiguration);
+              const sharingConfiguration = {
+                    // This is iOS specific. All values will be ignored on Android platform.
+                    // All the following values are fake. Please read a native PowerAuth mobile SDK documentation
+                    // about activation data sharing that explains how to prepare parameters in detail.
+                    appGroup: "group.your.app.group",
+                    appIdentifier: "some.identifier",
+                    keychainAccessGroup: "keychain.access.group"
+              };
+              await this.powerAuth.configure(configuration, clientConfiguration, biometryConfiguration, keychainConfiguration, sharingConfiguration);
               console.log("PowerAuth configuration successfull.");
             } catch(e) {
                 console.log(`PowerAuth failed to configure: ${e.code}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,8 @@ export * from './model/PowerAuthConfirmRecoveryCodeDataResult';
 export * from './model/PowerAuthCreateActivationResult';
 export * from './model/PowerAuthError';
 export * from './model/PowerAuthKeychainConfiguration';
+export * from './model/PowerAuthSharingConfiguration';
+export * from './model/PowerAuthExternalPendingOperation';
 export * from './model/PowerAuthRecoveryActivationData';
 export * from './model/PowerAuthPassword';
 export * from './model/PowerAuthEncryptor';

--- a/src/model/PowerAuthError.ts
+++ b/src/model/PowerAuthError.ts
@@ -184,6 +184,15 @@ export enum PowerAuthErrorCode {
     BIOMETRY_FAILED = "BIOMETRY_FAILED",
 
     /**
+     * ### iOS Specific
+     * 
+     * The requested function is not available due to an external application is doing the sensitive operation
+     * at the same time. The recommended action is to instruct the user to switch to the application that started
+     * the sensitive operation. You can investigate the type of operation by calling `PowerAuth.getExternalPendingOperation()`.
+     */
+    EXTERNAL_PENDING_OPERATION = "EXTERNAL_PENDING_OPERATION",
+
+    /**
      * When password is not set during activation commit.
      * @deprecated "WRONG_PARAM" is returned in this case.
      */

--- a/src/model/PowerAuthExternalPendingOperation.ts
+++ b/src/model/PowerAuthExternalPendingOperation.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * ### iOS specific
+ * 
+ * The `PowerAuthExternalPendingOperationType` defines types of operation
+ * started in another application that share activation data.
+ */
+export type PowerAuthExternalPendingOperationType = "ACTIVATION" | "PROTOCOL_UPGRADE"
+
+/**
+ * ### iOS specific
+ * 
+ * The `PowerAuthExternalPendingOperation` interface contains data that can identify an external
+ * application that started the critical operation.
+ */
+export interface PowerAuthExternalPendingOperation {
+    /**
+     * Type of operation running in another application.
+     */
+    externalOperationType: PowerAuthExternalPendingOperationType
+    /**
+     * Identifier of external application that started the operation. This is the same identifier
+     * you provided to `PowerAuthSharingConfiguration` during the PowerAuth initialization.
+     */
+    externalApplicationId: string
+}

--- a/src/model/PowerAuthSharingConfiguration.ts
+++ b/src/model/PowerAuthSharingConfiguration.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Interface that representing the activation data sharing settings.
+ */
+export interface PowerAuthSharingConfigurationType {
+    /**
+     * ### iOS specific
+     * 
+     * Name of app group that allows you sharing data between multiple applications. Be aware that the value 
+     * overrides `accessGroupName` property if it's provided in `PowerAuthKeychainConfiguration`.
+     * 
+     * The UTF-8 representation of this string should not exceed 26 bytes, due to internal limitations applied
+     * on the operating system level.
+     */
+    readonly appGroup: string
+    /**
+     * ### iOS specific
+     * 
+     * Unique application identifier. This identifier helps you to determine which application
+     * currently holds the lock on activation data in a special operations.
+     *
+     * The length of identifier cannot exceed 127 bytes if represented as UTF-8 string. It's recommended
+     * to use application's main bundle identifier, but in general, it's up to you how you identify your
+     * own applications.
+     */
+    readonly appIdentifier: string
+    /**
+     * ### iOS specific
+     * 
+     * Keychain access group name used by the PowerAuthSDK keychain instances.
+     */
+    readonly keychainAccessGroup: string
+
+    /**
+     * ### iOS specific
+     * 
+     * Optional identifier of memory shared between the applications in app group. If identifier is not provided
+     * then PowerAuthSDK calculate unique identifier based on `PowerAuth.instanceId`.
+     *
+     * You can set this property in case that PowerAuth SDK generates identifier that collide with your application's
+     * functionality. The configuration of PowerAuthSDK instance always contains an actual identifier used for its
+     * shared memory initialization, so you can test whether the generated identifier is OK.
+     *
+     * The length of identifier cannot exceed 4 bytes if represented as UTF8 string. This is an operating system
+     * limitation.
+     */
+    readonly sharedMemoryIdentifier?: string
+}
+
+/**
+ * ### iOS specific
+ * 
+ * The `PowerAuthSharingConfiguration` class contains configuration required for PowerAuthSDK instances shared 
+ * accross multiple applications or application and its native extensions.
+ */
+export class PowerAuthSharingConfiguration implements PowerAuthSharingConfigurationType {
+    appGroup: string
+    appIdentifier: string
+    keychainAccessGroup: string
+    sharedMemoryIdentifier?: string
+    /**
+     * Construct configuration with required parameters
+     * @param appGroup Name of app group that allows you sharing data between multiple applications.
+     * @param appIdentifier Unique application identifier. This identifier helps you to determine which application currently holds the lock on activation data in a special operations.
+     * @param keychainAccessGroup Keychain access group name used by the PowerAuthSDK keychain instances.
+     * @param sharedMemoryIdentifier Optional identifier of memory shared between the applications in app group.
+     */
+    constructor(appGroup: string, appIdentifier: string, keychainAccessGroup: string, sharedMemoryIdentifier: string | undefined = undefined) {
+        this.appGroup = appGroup
+        this.appIdentifier = appIdentifier
+        this.keychainAccessGroup = keychainAccessGroup
+        this.sharedMemoryIdentifier = sharedMemoryIdentifier
+    }
+}
+
+/**
+ * Function create a frozen object implementing `PowerAuthSharingConfigurationType` with all required properties set.
+ * @param input Optional application's configuration. If not provided, then the default values are set.
+ * @returns Frozen object implementing `PowerAuthSharingConfigurationType` with additional property indicating that configuration is provided.
+ */
+export function buildSharingConfiguration(input: PowerAuthSharingConfigurationType | undefined = undefined): PowerAuthSharingConfigurationType {
+    return Object.freeze({
+        appGroup: input?.appGroup ?? "",
+        appIdentifier: input?.appIdentifier ?? "",
+        keychainAccessGroup: input?.keychainAccessGroup ?? "",
+        sharedMemoryIdentifier: input?.sharedMemoryIdentifier ?? "",
+        isProvided: input !== undefined
+    })
+}

--- a/testapp/_tests/PowerAuth_Activation.test.ts
+++ b/testapp/_tests/PowerAuth_Activation.test.ts
@@ -41,6 +41,7 @@ export class PowerAuth_ActivationTests extends TestWithActivation {
         expect(await sdk.hasValidActivation()).toBe(false)
         expect(await sdk.getActivationIdentifier()).toBeUndefined()
         expect(await sdk.getActivationFingerprint()).toBeUndefined()
+        expect(await sdk.getExternalPendingOperation()).toBeUndefined()
 
         await this.runFailingMethodsDuringActivation('BEGIN', PowerAuthErrorCode.MISSING_ACTIVATION, PowerAuthErrorCode.MISSING_ACTIVATION)
         await expect(async () => await sdk.commitActivation(this.credentials.invalidKnowledge)).toThrow({errorCode: PowerAuthErrorCode.INVALID_ACTIVATION_STATE})

--- a/testapp/_tests/PowerAuth_Configure.test.ts
+++ b/testapp/_tests/PowerAuth_Configure.test.ts
@@ -60,6 +60,8 @@ export class PowerAuth_ConfigureTests extends TestWithServer {
         expect(sdk2.clientConfiguration).toBeDefined()
         expect(sdk1.biometryConfiguration).toBeDefined()
         expect(sdk2.biometryConfiguration).toBeDefined()
+        expect(sdk1.sharingConfiguration).toBeDefined()
+        expect(sdk2.sharingConfiguration).toBeDefined()
 
         // pa1 & pa2 should be configured now, because PowerAuth is just a thin envelope
         // keeping only essential values
@@ -74,6 +76,8 @@ export class PowerAuth_ConfigureTests extends TestWithServer {
         expect(pa2.clientConfiguration).toBeDefined()
         expect(pa1.biometryConfiguration).toBeDefined()
         expect(pa2.biometryConfiguration).toBeDefined()
+        expect(pa1.sharingConfiguration).toBeDefined()
+        expect(pa2.sharingConfiguration).toBeDefined()
     }
 
     async testReconfigureWhileActive() {
@@ -93,6 +97,8 @@ export class PowerAuth_ConfigureTests extends TestWithServer {
         const keychainConfig2 = sdk2.keychainConfiguration
         const biometryConfig1 = sdk1.biometryConfiguration
         const biometryConfig2 = sdk2.biometryConfiguration
+        const sharingConfig1 = sdk1.sharingConfiguration
+        const sharingConfig2 = sdk2.sharingConfiguration
 
         expect(config1).toBeDefined()
         expect(config2).toBeDefined()
@@ -102,6 +108,8 @@ export class PowerAuth_ConfigureTests extends TestWithServer {
         expect(keychainConfig2).toBeDefined()
         expect(biometryConfig1).toBeDefined()
         expect(biometryConfig2).toBeDefined()
+        expect(sharingConfig1).toBeDefined()
+        expect(sharingConfig2).toBeDefined()
 
         await helper1.createActivation(undefined, this.prepareData(this.instance1))
         await helper2.createActivation(undefined, this.prepareData(this.instance2))
@@ -131,6 +139,16 @@ export class PowerAuth_ConfigureTests extends TestWithServer {
 
         expect(await sdk1.validatePassword(this.password1)).toSucceed()
         expect(await sdk2.validatePassword(this.password2)).toSucceed()
+    }
+
+    async iosTestActivationSharing() {
+        const helper1 = await this.getHelper1()
+        const sdk1 = helper1.powerAuthSdk
+        expect(await sdk1.isConfigured()).toBe(true)
+        expect(sdk1.sharingConfiguration?.appGroup).toBe("group.com.wultra.testGroup")
+        expect(sdk1.sharingConfiguration?.appIdentifier).toBe("SharedInstanceTests")
+        expect(sdk1.sharingConfiguration?.keychainAccessGroup).toBe("fake.accessGroup")
+        expect(sdk1.sharingConfiguration?.sharedMemoryIdentifier).toBe("tst1")
     }
 
     async runMethodsThatMustFail(sdk: PowerAuth) {
@@ -216,6 +234,19 @@ export class PowerAuth_ConfigureTests extends TestWithServer {
     customizePowerAuthActivation(activation: PowerAuthActivation) {}
 
     prepareData(instanceId: string): CustomActivationHelperPrepareData {
+        if (this.currentTestName === 'iosTestActivationSharing') {
+            return {
+                powerAuthInstanceId: instanceId,
+                useConfigObjects: true,
+                password: instanceId === this.instance1 ? this.password1 : this.password2,
+                sharingConfiguration: {
+                    appGroup: "group.com.wultra.testGroup",
+                    appIdentifier: "SharedInstanceTests",
+                    keychainAccessGroup: "fake.accessGroup", // This will work only in simulator
+                    sharedMemoryIdentifier: "tst1"
+                }
+            }
+        }
         return {
             powerAuthInstanceId: instanceId,
             useConfigObjects: true,

--- a/testapp/_tests/helpers/RNActivationHelper.ts
+++ b/testapp/_tests/helpers/RNActivationHelper.ts
@@ -24,7 +24,8 @@ import {
     PowerAuthClientConfiguration,
     PowerAuthConfiguration,
     PowerAuthCreateActivationResult,
-    PowerAuthKeychainConfiguration } from 'react-native-powerauth-mobile-sdk'
+    PowerAuthKeychainConfiguration, 
+    PowerAuthSharingConfiguration} from 'react-native-powerauth-mobile-sdk'
 import { RNHttpClient } from './RNHttpClient'
 
 /**
@@ -92,6 +93,11 @@ export interface CustomActivationHelperPrepareData extends ActivationHelperPrepa
      * Note that the configuration will be ignored if `useConfigObjects` is false and `instanceConfig` is undefined. 
      */
     biometryConfig?: PowerAuthBiometryConfiguration
+    /**
+     * If provided, then this sharing configuration will be applied to PowerAuth instance.
+     * Note that the configuration will be ignored if `useConfigObjects` is false and `instanceConfig` is undefined.
+     */
+    sharingConfiguration?: PowerAuthSharingConfiguration
 }
 
 /**
@@ -121,7 +127,7 @@ export async function createActivationHelper(server: PowerAuthTestServer, cfg: T
                 clientConfig = new PowerAuthClientConfiguration()
                 clientConfig.enableUnsecureTraffic = allowUnsecure
             }
-            await sdk.configure(instanceConfig, clientConfig, pd.biometryConfig,  pd.keychainConfig)
+            await sdk.configure(instanceConfig, clientConfig, pd.biometryConfig,  pd.keychainConfig, pd.sharingConfiguration)
         } else {
             // Use legacy configuration
             await sdk.configure(appSetup.appKey, appSetup.appSecret, appSetup.masterServerPublicKey, cfg.enrollment.baseUrl, allowUnsecure)

--- a/testapp/ios/Podfile.lock
+++ b/testapp/ios/Podfile.lock
@@ -15,9 +15,9 @@ PODS:
     - hermes-engine/Pre-built (= 0.71.6)
   - hermes-engine/Pre-built (0.71.6)
   - libevent (2.1.12)
-  - PowerAuth2 (1.7.8):
-    - PowerAuthCore (~> 1.7.8)
-  - PowerAuthCore (1.7.8)
+  - PowerAuth2 (1.7.9):
+    - PowerAuthCore (~> 1.7.9)
+  - PowerAuthCore (1.7.9)
   - RCT-Folly (2021.07.22.00):
     - boost
     - DoubleConversion
@@ -492,8 +492,8 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: b434cea529ad0152c56c7cb6486b0c4c0b23b5de
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  PowerAuth2: a48e01f00af5f5a087cdd328597e07584bd52cef
-  PowerAuthCore: 6d509d68db1cac9ac541205516f6a080d85d1195
+  PowerAuth2: 4672bfcab640cec9dd1fa53a9729fcc23867e992
+  PowerAuthCore: f228a87fb30f240f49c353fb403010d1d4ff7407
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 5c6fd63b03abb06947d348dadac51c93e3485bd8
   RCTTypeSafety: 1c66daedd66f674e39ce9f40782f0d490c78b175
@@ -525,6 +525,6 @@ SPEC CHECKSUMS:
   ReactCommon: 0c43eaeaaee231d7d8dc24fc5a6e4cf2b75bf196
   Yoga: ba09b6b11e6139e3df8229238aa794205ca6a02a
 
-PODFILE CHECKSUM: ceffd6bd1db0bcf2c7de6fe69e15756895aeb9c3
+PODFILE CHECKSUM: 7bd465c750033c5e92722113bbf2c8741bb3e0c0
 
 COCOAPODS: 1.15.2

--- a/testapp/ios/testapp.xcodeproj/project.pbxproj
+++ b/testapp/ios/testapp.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		5709B34CF0A7D63546082F79 /* Pods-testapp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-testapp.release.xcconfig"; path = "Target Support Files/Pods-testapp/Pods-testapp.release.xcconfig"; sourceTree = "<group>"; };
 		5DCACB8F33CDC322A6C60F78 /* libPods-testapp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-testapp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = testapp/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		BF9FCA252C8F1BC100F6E1BE /* testapp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = testapp.entitlements; path = testapp/testapp.entitlements; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -81,6 +82,7 @@
 		13B07FAE1A68108700A75B9A /* testapp */ = {
 			isa = PBXGroup;
 			children = (
+				BF9FCA252C8F1BC100F6E1BE /* testapp.entitlements */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.mm */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
@@ -414,6 +416,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = testapp/testapp.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = KTT9G859MR;
 				ENABLE_BITCODE = NO;
@@ -442,6 +445,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = testapp/testapp.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = KTT9G859MR;
 				INFOPLIST_FILE = testapp/Info.plist;

--- a/testapp/ios/testapp/testapp.entitlements
+++ b/testapp/ios/testapp/testapp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.wultra.testGroup</string>
+	</array>
+</dict>
+</plist>

--- a/testapp/package-lock.json
+++ b/testapp/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "chalk": "^4.1.0",
-        "powerauth-js-test-client": "^0.2.9",
+        "powerauth-js-test-client": "^0.2.12",
         "react": "18.2.0",
         "react-native": "0.71.6",
         "react-native-config": "^1.5.0",
@@ -8623,9 +8623,9 @@
       }
     },
     "node_modules/powerauth-js-test-client": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/powerauth-js-test-client/-/powerauth-js-test-client-0.2.9.tgz",
-      "integrity": "sha512-tam5DpQajZ/442WoXCU3tVNLSkJVBINrvsrvkhQ04qA5wRx/GrcMT4JT48Up7iSzvcfMv9ky2DmYdmIKZPD3jA==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/powerauth-js-test-client/-/powerauth-js-test-client-0.2.12.tgz",
+      "integrity": "sha512-PhYSVQU+oMPiwhDD5H8OGXMuU0eQ0RKqfAKlL7aCUNXvp3dKNF5ib1Y7jtrUxI1telpBVXONOX8IGLjLNLDNGA==",
       "dependencies": {
         "cross-fetch": "^3.1.5",
         "js-base64": "^3.7.2"
@@ -8917,8 +8917,8 @@
     },
     "node_modules/react-native-powerauth-mobile-sdk": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/react-native-powerauth-mobile-sdk/-/react-native-powerauth-mobile-sdk-2.5.0.tgz",
-      "integrity": "sha512-4rQ1XY40KGQlVGMYekMHVpEFh2pJbdQmJxTNJht77Zy42laHt7FuLrXIxNvQj692jQzOFVcNPLccqrYg1piqyQ==",
+      "resolved": "file:../react-native-powerauth-mobile-sdk-2.5.0.tgz",
+      "integrity": "sha512-2TVKInu6C/tmYR7Z95SzKqDWHOLuWcwaQsxfdTZWsCUazjdi4y3KMJeVro3F9Y1p+qcZ7jSrdYvMPbvUmBqc+w==",
       "dependencies": {
         "node-fetch": ">=2.6.1"
       },
@@ -17145,9 +17145,9 @@
       "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg=="
     },
     "powerauth-js-test-client": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/powerauth-js-test-client/-/powerauth-js-test-client-0.2.9.tgz",
-      "integrity": "sha512-tam5DpQajZ/442WoXCU3tVNLSkJVBINrvsrvkhQ04qA5wRx/GrcMT4JT48Up7iSzvcfMv9ky2DmYdmIKZPD3jA==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/powerauth-js-test-client/-/powerauth-js-test-client-0.2.12.tgz",
+      "integrity": "sha512-PhYSVQU+oMPiwhDD5H8OGXMuU0eQ0RKqfAKlL7aCUNXvp3dKNF5ib1Y7jtrUxI1telpBVXONOX8IGLjLNLDNGA==",
       "requires": {
         "cross-fetch": "^3.1.5",
         "js-base64": "^3.7.2"
@@ -17365,9 +17365,8 @@
       "integrity": "sha512-7F6bD7B8Xsn3JllxcwHhFcsl9aHIig47+3eN4IHFNqfLhZr++3ElDrcqfMzugM+niWbaMi7bJ0kAkAL8eCpdWg=="
     },
     "react-native-powerauth-mobile-sdk": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/react-native-powerauth-mobile-sdk/-/react-native-powerauth-mobile-sdk-2.5.0.tgz",
-      "integrity": "sha512-4rQ1XY40KGQlVGMYekMHVpEFh2pJbdQmJxTNJht77Zy42laHt7FuLrXIxNvQj692jQzOFVcNPLccqrYg1piqyQ==",
+      "version": "file:../react-native-powerauth-mobile-sdk-2.5.0.tgz",
+      "integrity": "sha512-2TVKInu6C/tmYR7Z95SzKqDWHOLuWcwaQsxfdTZWsCUazjdi4y3KMJeVro3F9Y1p+qcZ7jSrdYvMPbvUmBqc+w==",
       "requires": {
         "node-fetch": ">=2.6.1"
       }

--- a/testapp/package.json
+++ b/testapp/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "chalk": "^4.1.0",
-    "powerauth-js-test-client": "^0.2.9",
+    "powerauth-js-test-client": "^0.2.12",
     "react": "18.2.0",
     "react-native": "0.71.6",
     "react-native-config": "^1.5.0",


### PR DESCRIPTION
This PR adds support for activation data sharing supported on iOS platform to RN wrapper configuration.