### PR TITLE
fix: Fix incorrect platform resolution on Cordova

### DIFF
--- a/other-platforms-support/cordova/src/internal/NativeCordovaModule.ts
+++ b/other-platforms-support/cordova/src/internal/NativeCordovaModule.ts
@@ -29,7 +29,7 @@ export abstract class NativeCordovaModule implements NativePowerAuthIfc {
                 cordova.exec(
                     // success callback
                     (response) => { 
-                        if (Utils.detectPlatform() == "android") {
+                        if (Utils.detectPlatform() === "android") {
                             resolve(response);
                         } else {
                             const parsed = JSON.parse(response);
@@ -38,7 +38,7 @@ export abstract class NativeCordovaModule implements NativePowerAuthIfc {
                     },
                     // error callback
                     (error) => {
-                        if (Utils.detectPlatform() == "android") {
+                        if (Utils.detectPlatform() === "android") {
                             reject(error)
                         } else {
                             reject(JSON.parse(error)) 

--- a/other-platforms-support/cordova/src/internal/Utils.ts
+++ b/other-platforms-support/cordova/src/internal/Utils.ts
@@ -18,13 +18,9 @@ export class Utils {
     
     static platformOs = this.detectPlatform()
 
-    // TODO: we should probably make this more robust
     private static detectPlatform(): string {
 
-        if (/iPad|iPhone|iPod/.test(navigator.userAgent)) {
-            return "ios";
-        }
-    
-        return "android"; // we consider everything else android
+        // @ts-expect-error
+        return cordova.platformId
     }
 }

--- a/src/internal/NativeWrapper.ts
+++ b/src/internal/NativeWrapper.ts
@@ -221,9 +221,9 @@ export class NativeWrapper {
             return new PowerAuthError(exception, message)
         } 
         // Otherwise handle the platform specific cases.
-        if (Utils.platformOs == "android") {
+        if (Utils.platformOs === "android") {
             return this.processAndroidException(exception, message)
-        } else if (Utils.platformOs == "ios") {
+        } else if (Utils.platformOs === "ios") {
             return this.processIosException(exception, message)
         } else {
             return new PowerAuthError(undefined, "Unsupported platform")

--- a/testapp-cordova/gulpfile.js
+++ b/testapp-cordova/gulpfile.js
@@ -34,14 +34,8 @@ class Platform {
     
     static OS = this.detectPlatform()
 
-    // TODO: we should probably make this more robust
     private static detectPlatform(): string {
-
-        if (/iPad|iPhone|iPod/.test(navigator.userAgent)) {
-            return "ios";
-        }
-    
-        return "android"; // we consider everything else android
+        return cordova.platformId
     }
 }
 `


### PR DESCRIPTION
Fixes #242 

The PR introduces a Cordova-native way to check the platform. It makes the same assumption about `cordova` object existence as we do when calling `cordova.exec`.
Also added platform check hardening.

Built & tested on Android API 34 + 36 phone, tablet & TV emulators.
Built & tested on iPhone 14 + 16 simulators, iPad Pro (M4) simulator.

NOTE: If this fix fails to be sufficient in the future, we should be able to use the tools exposed later with #240 ..