### PR TITLE
Environment Info

### DIFF
--- a/android/src/main/java/com/wultra/android/powerauth/js/PowerAuthJsModule.kt
+++ b/android/src/main/java/com/wultra/android/powerauth/js/PowerAuthJsModule.kt
@@ -19,6 +19,7 @@ package com.wultra.android.powerauth.js
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
+import android.content.pm.PackageManager
 import android.os.Build
 import android.util.Base64
 import android.util.Pair
@@ -1094,6 +1095,35 @@ class PowerAuthJsModule(
         } else {
             promise.resolve(corrected)
         }
+    }
+
+    @JsApiMethod
+    fun getEnvironmentInfo(promise: Promise) {
+
+        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            PackageManager.GET_SIGNING_CERTIFICATES
+        } else {
+            @Suppress("DEPRECATION")
+            PackageManager.GET_SIGNATURES
+        }
+        val appInfo = try {
+            this.context.packageManager.getPackageInfo(this.context.packageName, flags)
+        } catch (e: PackageManager.NameNotFoundException) {
+            null
+        }
+
+        val map: WritableMap = Arguments.createMap()
+        
+        map.putString("systemName", "android")
+        map.putString("systemVersion", Build.VERSION.RELEASE)
+
+        map.putString("applicationVersion", appInfo?.versionName)
+        map.putString("applicationIdentifier", appInfo?.packageName)
+
+        map.putString("deviceManufacturer", Build.BRAND)
+        map.putString("deviceId", Build.MODEL)
+
+        promise.resolve(map)
     }
 
 

--- a/android/src/main/java/com/wultra/android/powerauth/reactnative/PowerAuthModule.java
+++ b/android/src/main/java/com/wultra/android/powerauth/reactnative/PowerAuthModule.java
@@ -293,4 +293,11 @@ public class PowerAuthModule extends ReactContextBaseJavaModule {
     public void correctTypedCharacter(int character, final Promise promise) {
         powerAuthJsModule.correctTypedCharacter(character, promise);
     }
+
+    // UTILS METHODS
+
+    @ReactMethod
+    public void getEnvironmentInfo(final Promise promise) {
+        powerAuthJsModule.getEnvironmentInfo(promise);
+    }
 }

--- a/docs/Accessing-Native-PowerAuthSDK.md
+++ b/docs/Accessing-Native-PowerAuthSDK.md
@@ -41,3 +41,7 @@ if (sdk != null) {
     // Do something with the native instance
 }
 ```
+
+## Read Next
+
+- [Additional Utilities](Additional-Utilities.md)

--- a/docs/Additional-Utilities.md
+++ b/docs/Additional-Utilities.md
@@ -1,6 +1,6 @@
 # Additional Utilities
 
-The PowerAuth Mobile SDK offers additional utility functions that can help with various tasks in your application. These utilities are available through the `PowerAuthUtils` class.
+The PowerAuth Mobile JS SDK offers additional utility functions that can help with various tasks in your application. These utilities are available through the `PowerAuthUtils` class.
 
 ## Available Methods
 

--- a/docs/Additional-Utilities.md
+++ b/docs/Additional-Utilities.md
@@ -1,0 +1,45 @@
+# Additional Utilities
+
+The PowerAuth Mobile SDK offers additional utility functions that can help with various tasks in your application. These utilities are available through the `PowerAuthUtils` class.
+
+## Available Methods
+
+### getEnvironmentInfo()
+
+Returns information about the current environment, including system details, device information, and SDK version.
+
+**Usage:**
+
+```typescript
+import { PowerAuthUtils } from 'react-native-powerauth-mobile-sdk';
+
+async function getDeviceInfo() {
+    try {
+        const environmentInfo = await PowerAuthUtils.getEnvironmentInfo();
+        console.log('Environment Info:', environmentInfo);
+        
+        // Access specific properties
+        console.log('System:', environmentInfo.systemName);
+        console.log('Version:', environmentInfo.systemVersion);
+        console.log('App Version:', environmentInfo.applicationVersion);
+        console.log('App ID:', environmentInfo.applicationIdentifier);
+        console.log('Device ID:', environmentInfo.deviceId);
+        console.log('Device Maker:', environmentInfo.deviceManufacturer);
+        console.log('SDK Version:', environmentInfo.sdkVersion);
+    } catch (error) {
+        console.error('Failed to get environment info:', error);
+    }
+}
+```
+
+**Response:**
+
+The method returns a `PowerAuthEnvironmentInfo` object with the following properties:
+
+- `systemName` (string): System name, for example "iOS", "Android", "iPadOS"
+- `systemVersion` (string): Version of the system
+- `applicationVersion` (string, optional): Application version, e.g. "1.0.0"
+- `applicationIdentifier` (string, optional): Host application identifier, for example "com.wultra.demoapp"
+- `deviceManufacturer` (string): Device manufacturer, for example "apple" or "Samsung"
+- `deviceId` (string): Device ID, for example "iPhone9,2"
+- `sdkVersion` (string): PowerAuth JS SDK version, for example "4.0.0"

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,10 +1,13 @@
 # Changelog
 
-## 4.0.0 TBD
+## 4.1.0 TBD
+- Opportunity to sign Base64 encoded data with `signDataWithDevicePrivateKey`
+  - we added the `dataFormat` parameter with possible `UTF8` and `BASE64` values for the data to be signed
+- `PowerAuthUtils` that provides `getEnvironmentInfo` with device, system and app data
+
+## 4.0.0 (5/2025)
 - Migration to the latest native PowerAuthSDK stack (1.9.x)
   - Use [migration guide](Version-4.0.md) for a smooth migration
-- Possibility to sign Base64 encoded data with `signDataWithDevicePrivateKey`
-  - we added the `dataFormat` parameter with possible `UTF8` and `BASE64` values for the data to be signed
 
 ## 3.1.0 TBD
 - Support for the new React Architecture

--- a/docs/Migration-Instructions.md
+++ b/docs/Migration-Instructions.md
@@ -13,4 +13,4 @@ When updating across multiple versions, you need to perform all migration steps 
 
 ## Read Next
 
-- [Troubleshooting](Troubleshooting.md)
+- [Sample Integration](Sample-Integration.md)

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -29,6 +29,10 @@ In order to connect to the [PowerAuth](https://www.wultra.com/mobile-security-su
 - [Migration Instructions](Migration-Instructions.md)
 - [Sample Integration](Sample-Integration.md)
 - [Accessing the Native PowerAuthSDK](Accessing-Native-PowerAuthSDK.md)
+- [Additional Utilities](Additional-Utilities.md)
+
+## Other
+- [Changelog](Changelog.md)
 <!-- end -->
 
 ## Support and compatibility

--- a/docs/Sample-Integration.md
+++ b/docs/Sample-Integration.md
@@ -9,3 +9,7 @@ The test application with the PowerAuth Mobile JS SDK integration can be found i
 <!-- begin box warning -->
 The test application is using our [`powerauth-js-test-client`](https://github.com/wultra/powerauth-js-test-client) library to manage activations on the server automatically. You suppose to don't do such thing in the real application.
 <!-- end -->
+
+## Read Next
+
+- [Accessing the Native PowerAuthSDK](Accessing-Native-PowerAuthSDK.md)

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -32,4 +32,4 @@ await PowerAuthDebug.dumpNativeObjects(powerAuth.instanceId);
 
 ## Read Next
 
-- [Sample Integration](Sample-Integration.md)
+- [Migration Instructions](Migration-Instructions.md)

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -5,7 +5,7 @@
 - [Device Activation](Device-Activation.md)
 - [Requesting Device Activation Status](Requesting-Device-Activation-Status.md)
 - [Data Signing](Data-Signing.md)
-- [Password Change](Password-Management.md)
+- [Password Management](Password-Management.md)
 - [Working with passwords securely](Secure-Password.md)
 - [Biometry Setup](Biometry-Setup.md)
 - [Device Activation Removal](Device-Activation-Removal.md)
@@ -20,6 +20,7 @@
 - [Migration Instructions](Migration-Instructions.md)
 - [Sample Integration](Sample-Integration.md)
 - [Accessing the Native PowerAuthSDK](Accessing-Native-PowerAuthSDK.md)
+- [Additional Utilities](Additional-Utilities.md)
 
 **Other**
 - [Changelog](Changelog.md)

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -35,6 +35,9 @@ const libVersion = pkg.version
 
 console.log(`\x1b[32m\n#########################\n## POWERAUTH MOBILE SDK JS BUILD\n## Library version: ${libVersion}\n#########################\n\x1b[0m`)
 
+// Create SDK verison file with the current version
+const patchSDKVersionTask = () => exec(`echo "// THIS FILE IS AUTO-GENERATED\nexport const SDK_VERSION = '${libVersion}';" > src/internal/SDKVersion.ts`);
+
 /***********************
 * REACT-NATIVE SECTION *
 ************************/
@@ -276,6 +279,7 @@ let cleanTemp = () => rimraf([ tmpDir ])
 const buildAllTask = gulp.series(
     cleanBuild,
     cleanTemp,
+    patchSDKVersionTask,
     gulp.parallel(
         RN_buildTask,
         //CAP_buildTask,
@@ -289,6 +293,6 @@ gulp.task("watch", () => { gulp.watch("src/ts/**/*.ts", buildAllTask) });
 gulp.task("default", buildAllTask);
 gulp.task("clean", gulp.parallel(cleanBuild, cleanTemp));
 gulp.task("purge", purge);
-gulp.task("rn", RN_buildTask);
-gulp.task("cap", CAP_buildTask);
-gulp.task("cdv", CDV_buildTask);
+gulp.task("rn", gulp.series(patchSDKVersionTask, RN_buildTask));
+// gulp.task("cap", gulp.series(patchSDKVersionTask, CAP_buildTask));
+gulp.task("cdv", gulp.series(patchSDKVersionTask, CDV_buildTask));

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -35,7 +35,7 @@ const libVersion = pkg.version
 
 console.log(`\x1b[32m\n#########################\n## POWERAUTH MOBILE SDK JS BUILD\n## Library version: ${libVersion}\n#########################\n\x1b[0m`)
 
-// Create SDK verison file with the current version
+// Create SDK version file with the current version
 const patchSDKVersionTask = () => exec(`echo "// THIS FILE IS AUTO-GENERATED\nexport const SDK_VERSION = '${libVersion}';" > src/internal/SDKVersion.ts`);
 
 /***********************

--- a/ios/PowerAuth/PAJS.h
+++ b/ios/PowerAuth/PAJS.h
@@ -99,6 +99,22 @@ typedef void (^RCTPromiseResolveBlock)(id result);
         [[self commandDelegate] sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonString] callbackId: cmd.callbackId]; \
     };
 
+#define PAJS_METHOD_NO_ARGS_START(name) \
+- (void)name:(CDVInvokedUrlCommand*)cmd \
+{ \
+    RCTPromiseRejectBlock reject = ^(NSString *code, NSString *message, NSError *error) { \
+        NSError *writeError = nil; \
+        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:@{ @"code": code ? code : [NSNull null], @"message": message ? message: [NSNull null] } options:NSJSONWritingPrettyPrinted error:&writeError]; \
+        NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];   \
+        [[self commandDelegate] sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:jsonString] callbackId: cmd.callbackId]; \
+    }; \
+    RCTPromiseResolveBlock resolve = ^(id result) { \
+        NSError *writeError = nil; \
+        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:@{ @"result": result ? result : [NSNull null] } options:NSJSONWritingPrettyPrinted error:&writeError]; \
+        NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];   \
+        [[self commandDelegate] sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:jsonString] callbackId: cmd.callbackId]; \
+    };
+
 #define PAJS_METHOD_END }
 
 #define PAJS_NULLABLE_ARGUMENT

--- a/ios/PowerAuth/PAJS.h
+++ b/ios/PowerAuth/PAJS.h
@@ -54,6 +54,11 @@ RCT_REMAP_METHOD(name,\
                  resolve:(RCTPromiseResolveBlock)resolve \
                  name##reject:(RCTPromiseRejectBlock)reject)
 
+#define PAJS_METHOD_NO_ARGS_START(name) \
+RCT_REMAP_METHOD(name,\
+                 resolve:(RCTPromiseResolveBlock)resolve \
+                 name##reject:(RCTPromiseRejectBlock)reject)
+
 #define PAJS_METHOD_END
 
 #define PAJS_INITIALIZE_METHOD initialize

--- a/ios/PowerAuth/PowerAuthModule.m
+++ b/ios/PowerAuth/PowerAuthModule.m
@@ -978,6 +978,27 @@ PAJS_METHOD_START(generateHeaderForToken,
 }
 PAJS_METHOD_END
 
+PAJS_METHOD_NO_ARGS_START(getEnvironmentInfo)
+{
+    UIDevice * currentDevice = [UIDevice currentDevice];
+    NSBundle * mainBundle = [NSBundle mainBundle];
+    NSDictionary * mainDictionary = [mainBundle infoDictionary];
+    NSString * appVersion = mainDictionary[@"CFBundleShortVersionString"];
+    NSString * appId = mainDictionary[@"CFBundleIdentifier"];
+    
+    resolve(@{
+        @"systemName": [currentDevice systemName],
+        @"systemVersion": [currentDevice systemVersion],
+        
+        @"applicationVersion": appVersion ? appVersion : [NSNull null],
+        @"applicationIdentifier": appId ? appId : [NSNull null],
+        
+        @"deviceManufacturer": @"apple",
+        @"deviceId": [currentDevice model]
+    });
+}
+PAJS_METHOD_END
+
 #pragma mark - Helper methods
 
 /// Validate instance identifier and call reject promise if identifier is invalid.

--- a/other-platforms-support/cordova/android/src/main/java/com/wultra/android/powerauth/cdv/PowerAuthModule.kt
+++ b/other-platforms-support/cordova/android/src/main/java/com/wultra/android/powerauth/cdv/PowerAuthModule.kt
@@ -217,6 +217,10 @@ class PowerAuthModule : CordovaPlugin() {
                 correctTypedCharacter(args, promise)
                 return true
             }
+            "getEnvironmentInfo" -> {
+                getEnvironmentInfo(args, promise)
+                return true
+            }
         }
         return false  // Returning false results in a "MethodNotFound" error.
     }
@@ -510,5 +514,11 @@ class PowerAuthModule : CordovaPlugin() {
     private fun correctTypedCharacter(args: JSONArray, promise: Promise) {
         val character = args.getInt(0)
         powerAuthJsModule.correctTypedCharacter(character, promise)
+    }
+
+    // UTILS METHODS
+    
+    private fun getEnvironmentInfo(args: JSONArray, promise: Promise) {
+        powerAuthJsModule.getEnvironmentInfo(promise)
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-powerauth-mobile-sdk",
   "title": "PowerAuth SDK for React Native Mobile Apps",
-  "version": "0.0.1.dev",
+  "version": "0.0.1-dev",
   "description": "Wultra PowerAuth Mobile SDK React Native component for iOS and Android",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-powerauth-mobile-sdk",
   "title": "PowerAuth SDK for React Native Mobile Apps",
-  "version": "3.0.0",
+  "version": "0.0.1.dev",
   "description": "Wultra PowerAuth Mobile SDK React Native component for iOS and Android",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/PowerAuthUtils.ts
+++ b/src/PowerAuthUtils.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NativeWrapper } from "./internal/NativeWrapper";
+import { SDK_VERSION } from "./internal/SDKVersion";
+
+/**
+ * The `PowerAuthUtils` class provides utility methods for the PowerAuth SDK.
+ */
+export class PowerAuthUtils {
+    /**
+     * Returns information about the current environment, such as system name, version, device ID,
+     * and the PowerAuth SDK version.
+     *
+     * @returns A promise that resolves to an object containing environment information.
+     */
+    static async getEnvironmentInfo(): Promise<PowerAuthEnvironmentInfo> {
+        const info = (await NativeWrapper.staticCall("getEnvironmentInfo")) as PowerAuthEnvironmentInfo
+        return { ...info, sdkVersion: SDK_VERSION } as PowerAuthEnvironmentInfo;
+    }
+}
+
+/**
+ * Interface representing the environment information for the PowerAuth SDK.
+ * This includes system details, application version or device information.
+ */
+export interface PowerAuthEnvironmentInfo {
+
+    /** System name, for example "iOS", "Android", "iPadOS", ... */
+    systemName: string
+    /** Version of the system */
+    systemVersion: string
+    
+    /** Application version, e.g. "1.0.0". */
+    applicationVersion?: string
+    /** Host application identifier, for example "com.wultra.demoapp" */
+    applicationIdentifier?: string
+
+    /** For example "apple" or "Samsung" */
+    deviceManufacturer: string
+    /** Device ID, for example "iPhone9,2" */
+    deviceId: string
+
+    /** PowerAuth JS SDK version, for example "4.0.0" */
+    sdkVersion: string
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@
 
 export * from './PowerAuth';
 export * from './PowerAuthActivationCodeUtil';
+export * from './PowerAuthUtils';
 export * from './PowerAuthTokenStore';
 export * from './PowerAuthPassphraseMeter';
 

--- a/src/internal/SDKVersion.ts
+++ b/src/internal/SDKVersion.ts
@@ -1,2 +1,2 @@
 // THIS FILE IS AUTO-GENERATED
-export const SDK_VERSION = '0.0.1.dev';
+export const SDK_VERSION = '0.0.1-dev';

--- a/src/internal/SDKVersion.ts
+++ b/src/internal/SDKVersion.ts
@@ -1,0 +1,2 @@
+// THIS FILE IS AUTO-GENERATED
+export const SDK_VERSION = '0.0.1.dev';

--- a/testapp/_tests/AllTests.ts
+++ b/testapp/_tests/AllTests.ts
@@ -18,6 +18,7 @@ import { TestSuite } from "../src/testbed/TestSuite";
 import { TestRunnerTests } from "./testbed/TestRunner.test";
 import { TestSuiteTests } from "./testbed/TestSuite.test";
 import { PowerAuthActivationCodeUtilTests } from "./PowerAuthActivationCodeUtil.test";
+import { PowerAuthUtilsTests } from "./PowerAuthUtils.test";
 import { PowerAuthActivationTests } from "./PowerAuthActivation.test";
 import { PowerAuth_ActivationTests } from "./PowerAuth_Activation.test";
 import { PowerAuth_RecoveryTests } from "./PowerAuth_Recovery.test";
@@ -51,6 +52,7 @@ export function getLibraryTests(): TestSuite[] {
         new PowerAuth_EncryptorTests(),
         new PowerAuthActivationTests(),
         new PowerAuthActivationCodeUtilTests(),
+        new PowerAuthUtilsTests(),
         new PowerAuthPasswordTests(),
         new PowerAuthPassphraseMeterTests(),
         new PowerAuth_LegacyAuthTests(),

--- a/testapp/_tests/PowerAuthUtils.test.ts
+++ b/testapp/_tests/PowerAuthUtils.test.ts
@@ -1,0 +1,47 @@
+//
+// Copyright 2022 Wultra s.r.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { PowerAuthUtils } from "react-native-powerauth-mobile-sdk";
+import { TestSuite, expect } from "../src/testbed";
+
+export class PowerAuthUtilsTests extends TestSuite {
+    
+    async iosTestEnvironmetInfo() {
+        const deviceInfo = await PowerAuthUtils.getEnvironmentInfo();
+        console.log(`Device info: ${JSON.stringify(deviceInfo)}`);
+        expect(deviceInfo).toBeDefined();
+        expect(deviceInfo.systemName).toBe("iOS");
+        expect(deviceInfo.systemVersion).toBeDefined();
+        expect(deviceInfo.deviceManufacturer).toBe("apple");
+        expect(deviceInfo.deviceId).toBeDefined();
+        expect(deviceInfo.sdkVersion).toBeDefined();
+        expect(deviceInfo.applicationVersion).toBe("1.0");
+        expect(deviceInfo.applicationIdentifier).toBeDefined();
+    }
+
+    async androidTestEnvironmetInfo() {
+        const deviceInfo = await PowerAuthUtils.getEnvironmentInfo();
+        console.log(`Device info: ${JSON.stringify(deviceInfo)}`);
+        expect(deviceInfo).toBeDefined();
+        expect(deviceInfo.systemName).toBe("android");
+        expect(deviceInfo.systemVersion).toBeDefined();
+        expect(deviceInfo.deviceManufacturer).toBeDefined();
+        expect(deviceInfo.deviceId).toBeDefined();
+        expect(deviceInfo.sdkVersion).toBeDefined();
+        expect(deviceInfo.applicationVersion).toBe("1.0");
+        expect(deviceInfo.applicationIdentifier).toBeDefined();
+    }
+}

--- a/testapp/_tests/PowerAuthUtils.test.ts
+++ b/testapp/_tests/PowerAuthUtils.test.ts
@@ -19,7 +19,7 @@ import { TestSuite, expect } from "../src/testbed";
 
 export class PowerAuthUtilsTests extends TestSuite {
     
-    async iosTestEnvironmetInfo() {
+    async iosTestEnvironmentInfo() {
         const deviceInfo = await PowerAuthUtils.getEnvironmentInfo();
         console.log(`Device info: ${JSON.stringify(deviceInfo)}`);
         expect(deviceInfo).toBeDefined();
@@ -32,7 +32,7 @@ export class PowerAuthUtilsTests extends TestSuite {
         expect(deviceInfo.applicationIdentifier).toBeDefined();
     }
 
-    async androidTestEnvironmetInfo() {
+    async androidTestEnvironmentInfo() {
         const deviceInfo = await PowerAuthUtils.getEnvironmentInfo();
         console.log(`Device info: ${JSON.stringify(deviceInfo)}`);
         expect(deviceInfo).toBeDefined();

--- a/testapp/package.json
+++ b/testapp/package.json
@@ -19,7 +19,7 @@
     "react": "19.0.0",
     "react-native": "0.78.0",
     "react-native-config": "^1.5.0",
-    "react-native-powerauth-mobile-sdk": "file:../build/react-native/react-native-powerauth-mobile-sdk-3.0.0.tgz"
+    "react-native-powerauth-mobile-sdk": "file:../build/react-native/react-native-powerauth-mobile-sdk-0.0.1.dev.tgz"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
Resolved #240:

Added `PowerAuthUtils.getEnvironmentInfo` that returns:

- `systemName` (string): System name, for example "iOS", "Android", "iPadOS"
- `systemVersion` (string): Version of the system
- `applicationVersion` (string, optional): Application version, e.g. "1.0.0"
- `applicationIdentifier` (string, optional): Host application identifier, for example "com.wultra.demoapp"
- `deviceManufacturer` (string): Device manufacturer, for example "apple" or "Samsung"
- `deviceId` (string): Device ID, for example "iPhone9,2"
- `sdkVersion` (string): PowerAuth JS SDK version, for example "4.0.0"