### PR TITLE
fix: Fix Android Encryptor crashing on missing putLong JNI bindings

### DIFF
--- a/android/src/main/java/com/wultra/android/powerauth/js/PowerAuthEncryptorJsModule.kt
+++ b/android/src/main/java/com/wultra/android/powerauth/js/PowerAuthEncryptorJsModule.kt
@@ -195,7 +195,7 @@ class PowerAuthEncryptorJsModule(
             cryptogram.putString("encryptedData", encryptionResult.second.getBodyBase64())
             cryptogram.putString("mac", encryptionResult.second.getMacBase64())
             cryptogram.putString("nonce", encryptionResult.second.getNonceBase64())
-            cryptogram.putLong("timestamp", encryptionResult.second.timestamp)
+            cryptogram.putDouble("timestamp", encryptionResult.second.timestamp.toDouble())
             val header: WritableMap = Arguments.createMap()
             header.putString("key", metadata.getHttpHeaderKey())
             header.putString("value", metadata.getHttpHeaderValue())

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## TBA
+- Fixed Android Encryptor crashing on missing `putLong` JNI bindings (issue [#264](https://github.com/wultra/react-native-powerauth-mobile-sdk/issues/264))
+
 ## 4.1.1 (7/2025)
 
 - Upgraded the [PowerAuth native SDK to `1.9.5`](https://github.com/wultra/powerauth-mobile-sdk/releases/tag/1.9.5)


### PR DESCRIPTION
Fixes #264 

This PR fixes a Meta issue spread across multiple RN versions.
The problem is that a "kotlinification" of RN between ~ `0.73` and `0.76` ported most of the internal writables to Kotlin from Java, but also moved them to the shared `JNI` implementation of the native buffers, regardless of architecture.
All versions between `0.76.x` - `0.78` have a correct Kotlin interface (e.g. [0.76](https://github.com/facebook/react-native/blob/0.76-stable/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableMap.kt)).
However, `putLong` method was missing in the native JNI API (e.g. [0.76](https://github.com/facebook/react-native/blob/0.76-stable/packages/react-native/ReactAndroid/src/main/jni/react/jni/WritableNativeMap.cpp)), resulting in the reported crash of a missing binding. It was only added in [this patch](https://github.com/facebook/react-native/commit/e7f943de2fd71d2259ab53e7817d2dcf96559f7e) to `0.78`+.

We missed this in our testing since we went from `0.72.x` old arch tooling straight to `0.79.x` new arch tooling..

The change should be safe since double gives us enough precision and we are already retrieving the native value as a double when reading from the decryptor, e.g.
```kotlin
if (cryptogram.hasKey("timestamp")) cryptogram.getDouble("timestamp").toLong() else 0
```