### PR TITLE
Synced time before token auth headers

### DIFF
--- a/android/src/main/java/com/wultra/android/powerauth/js/PowerAuthJsModule.kt
+++ b/android/src/main/java/com/wultra/android/powerauth/js/PowerAuthJsModule.kt
@@ -15,7 +15,6 @@
  */
 package com.wultra.android.powerauth.js
 
-
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
@@ -36,7 +35,6 @@ import io.getlime.security.powerauth.networking.ssl.HttpClientSslNoValidationStr
 import io.getlime.security.powerauth.sdk.*
 import io.getlime.security.powerauth.sdk.impl.MainThreadExecutor
 import java.nio.charset.StandardCharsets
-
 
 class PowerAuthJsModule(
     private val context: Context,
@@ -1018,20 +1016,19 @@ class PowerAuthJsModule(
         val context: Context = this.context
         this.usePowerAuth(instanceId, promise, object : PowerAuthBlock {
             override fun run(sdk: PowerAuthSDK) {
-                val token: PowerAuthToken? = sdk.tokenStore.getLocalToken(context, tokenName)
-                if (token == null) {
-                    promise.reject(
-                        Errors.EC_LOCAL_TOKEN_NOT_AVAILABLE,
-                        "This token is no longer available in the local store."
-                    )
-                } else if (token.canGenerateHeader()) {
-                    promise.resolve(getHttpHeaderObject(token.generateHeader()))
-                } else {
-                    promise.reject(
-                        Errors.EC_CANNOT_GENERATE_TOKEN,
-                        "Cannot generate header for this token."
-                    )
-                }
+                sdk.tokenStore.generateAuthorizationHeader(context, tokenName, object: IGenerateTokenHeaderListener {
+                    override fun onGenerateTokenHeaderSucceeded(header: PowerAuthAuthorizationHttpHeader) {
+                        promise.resolve(getHttpHeaderObject(header))
+                    }
+
+                    override fun onGenerateTokenHeaderFailed(t: Throwable) {
+                        promise.reject(
+                            Errors.EC_CANNOT_GENERATE_TOKEN,
+                            "Cannot generate header for this token.",
+                            t
+                        )
+                    }
+                })
             }
         })
     }

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## TBA
+- Token-based authentication now automatically synchronizes time if needed (see [Token-Based Authentication](./Token-Based-Authentication.md) for more details)
+
+## 4.1.2 (9/2025)
 - Fixed Android Encryptor crashing on missing `putLong` JNI bindings (issue [#264](https://github.com/wultra/react-native-powerauth-mobile-sdk/issues/264))
 - Added [Time Synchronization service](./Time-Synchronization.md)
 

--- a/docs/Time-Synchronization.md
+++ b/docs/Time-Synchronization.md
@@ -12,9 +12,10 @@ const timeService = powerAuthSDK.timeSynchronizationService
 
 The time is synchronized automatically in the following situations:
 
-- After an activation is created
-- After getting an activation status
-- After receiving any response encrypted with our End-To-End Encryption scheme
+- After an [activation is created](Device-Activation.md)
+- After getting an [activation status](Requesting-Device-Activation-Status.md)
+- After receiving any response encrypted with our [End-To-End Encryption scheme](End-To-End-Encryption.md)
+- After generating an authorization header for a token (see [Token-Based Authentication](Token-Based-Authentication.md) for more details)
 
 <!-- begin box warning -->
 The time synchronization is reset automatically once your application transitions from the background to the foreground.

--- a/docs/Token-Based-Authentication.md
+++ b/docs/Token-Based-Authentication.md
@@ -46,6 +46,9 @@ try {
 }
 ```
 
+If time is not synchronized with the server before the header generation, it will be performed automatically during this call (an HTTP request). 
+This behavior ensures that the generated token is always valid, even if the device's clock is slightly off.
+
 ## Removing Token From the Server
 
 To remove the token from the server, you can use the following code:

--- a/ios/PowerAuth/PowerAuthModule.m
+++ b/ios/PowerAuth/PowerAuthModule.m
@@ -957,23 +957,16 @@ PAJS_METHOD_START(generateHeaderForToken,
                   PAJS_ARGUMENT(tokenName, PAJS_NONNULL_ARGUMENT NSString*))
 {
     PA_BLOCK_START
-    PowerAuthToken* token = [[powerAuth tokenStore] localTokenWithName:tokenName];
-    if (token == nil) {
-        reject(EC_LOCAL_TOKEN_NOT_AVAILABLE, @"This token is no longer available in the local store.", nil);
-    }
-    else if ([token canGenerateHeader]) {
-        PowerAuthAuthorizationHttpHeader* header = [token generateHeader];
+    [[powerAuth tokenStore] generateAuthorizationHeaderWithName:tokenName completion:^(PowerAuthAuthorizationHttpHeader * header, NSError * error) {
         if (header) {
             resolve(@{
                 @"key": header.key,
                 @"value": header.value
             });
         } else {
-            reject(EC_CANNOT_GENERATE_TOKEN, @"Cannot generate header for this token.", nil);
+            reject(EC_CANNOT_GENERATE_TOKEN, @"Failed to generate header for this token.", error);
         }
-    } else {
-        reject(EC_CANNOT_GENERATE_TOKEN, @"Cannot generate header for this token.", nil);
-    }
+    }];
     PA_BLOCK_END
 }
 PAJS_METHOD_END

--- a/src/PowerAuthTokenStore.ts
+++ b/src/PowerAuthTokenStore.ts
@@ -100,6 +100,8 @@ export class PowerAuthTokenStore {
     /**
      * Generates a http header for the token in local storage.
      * 
+     * If needed, the method automatically performs time synchronization (via additional HTTP request).
+     * 
      * @param tokenName Name of token in the local storage that will be used for generating
      * @returns header or throws
      */

--- a/testapp/_tests/PowerAuth_Token.test.ts
+++ b/testapp/_tests/PowerAuth_Token.test.ts
@@ -21,6 +21,7 @@ import { TestWithActivation } from "./helpers/TestWithActivation";
 export class PowerAuth_TokenTests extends TestWithActivation {
 
     async testTokenManagement() {
+
         const T1 = 'possessionToken'
         const T1_cred = this.credentials!.possession
         const T1_invCred = this.credentials!.knowledge
@@ -34,8 +35,8 @@ export class PowerAuth_TokenTests extends TestWithActivation {
         expect(await tokenStore.hasLocalToken(T1)).toBe(false)
         expect(await tokenStore.hasLocalToken(T2)).toBe(false)
 
-        await expect(async () => await tokenStore.generateHeaderForToken(T1)).toThrow({errorCode: PowerAuthErrorCode.LOCAL_TOKEN_NOT_AVAILABLE})
-        await expect(async () => await tokenStore.generateHeaderForToken(T2)).toThrow({errorCode: PowerAuthErrorCode.LOCAL_TOKEN_NOT_AVAILABLE})
+        await expect(async () => await tokenStore.generateHeaderForToken(T1)).toThrow({errorCode: PowerAuthErrorCode.CANNOT_GENERATE_TOKEN})
+        await expect(async () => await tokenStore.generateHeaderForToken(T2)).toThrow({errorCode: PowerAuthErrorCode.CANNOT_GENERATE_TOKEN})
         await expect(async () => await tokenStore.getLocalToken(T1)).toThrow({errorCode: PowerAuthErrorCode.LOCAL_TOKEN_NOT_AVAILABLE})
         await expect(async () => await tokenStore.getLocalToken(T2)).toThrow({errorCode: PowerAuthErrorCode.LOCAL_TOKEN_NOT_AVAILABLE})
 
@@ -77,12 +78,12 @@ export class PowerAuth_TokenTests extends TestWithActivation {
         // remove locally
         await expect(async () => await tokenStore.removeLocalToken(T1)).toSucceed()
         expect(await tokenStore.hasLocalToken(T1)).toBe(false)
-        await expect(async () => await tokenStore.generateHeaderForToken(T1)).toThrow({errorCode: PowerAuthErrorCode.LOCAL_TOKEN_NOT_AVAILABLE})
+        await expect(async () => await tokenStore.generateHeaderForToken(T1)).toThrow({errorCode: PowerAuthErrorCode.CANNOT_GENERATE_TOKEN})
         
         // remove on the server
         await expect(async () => await tokenStore.removeAccessToken(T2)).toSucceed()
         expect(await tokenStore.hasLocalToken(T2)).toBe(false)
-        await expect(async () => await tokenStore.generateHeaderForToken(T2)).toThrow({errorCode: PowerAuthErrorCode.LOCAL_TOKEN_NOT_AVAILABLE})
+        await expect(async () => await tokenStore.generateHeaderForToken(T2)).toThrow({errorCode: PowerAuthErrorCode.CANNOT_GENERATE_TOKEN})
     }
 
     async testTokenCalculation() {
@@ -104,32 +105,20 @@ export class PowerAuth_TokenTests extends TestWithActivation {
         expect(token2.tokenIdentifier).toBeDefined()
         expect(token2.tokenName).toBe(T2)
 
+        await this.sdk.timeSynchronizationService.resetTimeSynchronization() // force time sync
+
         const header1 = await tokenStore.generateHeaderForToken(T1)
         expect(header1.value).toBeDefined()
-        // const result1 = await this.verifyTokenDigest(header1.value)
-        // expect(result1.tokenValid).toBe(true)
-        // expect(result1.activationId).toBe(activationId)
-        // expect(result1.signatureType).toBe('POSSESSION')
+        const result1 = await this.helper.verifyToken(header1.value)
+        expect(result1.tokenValid).toBe(true)
+        expect(result1.registrationId).toBe(activationId)
+        expect(result1.signatureType).toBe('POSSESSION')
 
         const header2 = await tokenStore.generateHeaderForToken(T2)
         expect(header2.value).toBeDefined()
-        // const result2 = await this.verifyTokenDigest(header2.value)
-        // expect(result2.tokenValid).toBe(true)
-        // expect(result2.activationId).toBe(activationId)
-        // expect(result2.signatureType).toBe('POSSESSION_KNOWLEDGE')
+        const result2 = await this.helper.verifyToken(header2.value)
+        expect(result2.tokenValid).toBe(true)
+        expect(result2.registrationId).toBe(activationId)
+        expect(result2.signatureType).toBe('POSSESSION_KNOWLEDGE')
     }
-
-    // TODO: not support in PowerAuth Cloud 
-    // async verifyTokenDigest(digest: TokenDigest | string, timeIsWrong: boolean = false): Promise<TokenDigestVerifyResult> {
-    //     try {
-    //         return await this.helper.tokenHelper.verifyTokenDigest(digest)
-    //     } catch (error) {
-    //         if (error instanceof PowerAuthServerError) {
-    //             if (Platform.OS === 'android' && error.httpStatusCode === 400 && error.serverErrorCode === 'ERR0030' && !timeIsWrong) {
-    //                 this.reportWarning(`It appears that time on Android Device is out of sync`)
-    //             }
-    //         }
-    //         throw error
-    //     }
-    // }
 }

--- a/testapp/src/IntegrationUtils.ts
+++ b/testapp/src/IntegrationUtils.ts
@@ -162,6 +162,15 @@ export class IntegrationHelper {
         return await this.makeCall(payload, `${AppConfig.cloudServerUrl}/v2/signature/verify`)
     }
 
+    async verifyToken(authHeader: string): Promise<TokenResponse> {
+        const payload = `
+            {
+                "authHeader": "${authHeader.replace(/\"/g, '\\\"')}"
+            }
+        `;
+        return await this.makeCall(payload, `${AppConfig.cloudServerUrl}/v2/token/verify`)
+    }
+
     // --- HELPER FUNCTIONS ---
 
     async callSDKEndpoint(endpoint: string, body: string, headers?: Headers, method: string = "POST"): Promise<any> {
@@ -236,4 +245,12 @@ interface SignatureResponse {
   registrationStatus: string
   signatureType: string
   remainingAttempts: number
+}
+
+interface TokenResponse {
+  tokenValid: boolean
+  userId?: string
+  registrationId?: string
+  registrationStatus?: string
+  signatureType?: string
 }


### PR DESCRIPTION
Fixes #275 

Using `generateAuthorizationHeader` for token authorization headers ensures that the time is synchronized.

Also improved the test to validate the generated headers.