### PR TITLE
feat: Implement storage cache API

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,8 @@
 
 ## TBA
 - Added `PowerAuthCryptoUtils` with functions for hashing and random bytes generation (see [Crypto Utilities](./Crypto-Utilities.md) for more details)
+- Added `PowerAuthStorageUtils` cache API with secure & standard storage (see [Storage Utilities](./Storage-Utilities.md))
+- Fixed bridged native error processing on Cordova (issue[#302](https://github.com/wultra/react-native-powerauth-mobile-sdk/issues/302))
 
 ## 4.1.3 (9/2025)
 - Token-based authentication now automatically synchronizes time if needed (see [Token-Based Authentication](./Token-Based-Authentication.md) for more details)

--- a/docs/Storage-Utilities.md
+++ b/docs/Storage-Utilities.md
@@ -1,0 +1,52 @@
+# Storage Utilities
+
+The PowerAuth Mobile JS SDK provides a simple cache API via `PowerAuthStorageUtils` for string key–value storage.
+
+## Storage Types
+
+- `PowerAuthStorageType.SECURE`  
+  - iOS: PowerAuth Keychain (Keychain service `com.wultra.powerauth.jssdk.storageutils.secure`)
+  - Android: PowerAuth Keychain (encrypted, backed by Android Keystore)
+
+- `PowerAuthStorageType.STANDARD`  
+  - iOS: UserDefaults suite `com.wultra.powerauth.jssdk.storageutils.standard`
+  - Android: SharedPreferences file `com.wultra.powerauth.jssdk.storageutils.standard`
+
+## Available Methods
+
+### setString(key: string, value: string, storageType: PowerAuthStorageType)
+Store a string value under a key.
+
+### getString(key: string, storageType: PowerAuthStorageType)
+Retrieve a string value. Returns `undefined` when the key is missing.
+
+### exists(key: string, storageType: PowerAuthStorageType)
+Check whether a key is present.
+
+### remove(key: string, storageType: PowerAuthStorageType)
+Remove a key. Returns `true` if the key existed.
+
+## Usage
+
+```typescript
+import { PowerAuthStorageUtils, PowerAuthStorageType } from 'react-native-powerauth-mobile-sdk';
+
+// Secure storage (Keychain / Android Keystore-backed)
+await PowerAuthStorageUtils.setString('session', '{"token":"abc"}', PowerAuthStorageType.SECURE);
+const secureValue = await PowerAuthStorageUtils.getString('session', PowerAuthStorageType.SECURE);
+
+// Standard storage (UserDefaults / SharedPreferences)
+await PowerAuthStorageUtils.setString('theme', 'dark', PowerAuthStorageType.STANDARD);
+const exists = await PowerAuthStorageUtils.exists('theme', PowerAuthStorageType.STANDARD);
+const removed = await PowerAuthStorageUtils.remove('theme', PowerAuthStorageType.STANDARD);
+```
+
+## Errors
+
+- `WRONG_PARAMETER`: invalid input (e.g., empty key, invalid storage type)
+- `ENCRYPTION_ERROR`: secure storage operation failed
+
+## Read Next
+
+- [Additional Utilities](Additional-Utilities.md)
+- [Accessing the Native PowerAuthSDK](Accessing-Native-PowerAuthSDK.md)

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -22,6 +22,7 @@
 - [User Info](User-Info.md)
 - [Time Synchronization](Time-Synchronization.md)
 - [Crypto Utilities](Crypto-Utilities.md)
+- [Storage Utilities](Storage-Utilities.md)
 - [Accessing the Native PowerAuthSDK](Accessing-Native-PowerAuthSDK.md)
 - [Additional Utilities](Additional-Utilities.md)
 

--- a/packages/cordova-powerauth-mobile-sdk/android/src/main/java/com/wultra/android/powerauth/cdv/PowerAuthStorageUtilsModule.kt
+++ b/packages/cordova-powerauth-mobile-sdk/android/src/main/java/com/wultra/android/powerauth/cdv/PowerAuthStorageUtilsModule.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wultra.android.powerauth.cordova.plugin
+
+import com.wultra.android.powerauth.cdv.util.Promise
+import com.wultra.android.powerauth.js.PowerAuthStorageUtilsJsModule
+import org.apache.cordova.CallbackContext
+import org.apache.cordova.CordovaInterface
+import org.apache.cordova.CordovaPlugin
+import org.apache.cordova.CordovaWebView
+import org.json.JSONArray
+import org.json.JSONException
+
+class PowerAuthStorageUtilsModule : CordovaPlugin() {
+
+    private lateinit var powerAuthStorageUtilsJsModule: PowerAuthStorageUtilsJsModule
+
+    override fun initialize(cordova: CordovaInterface, webView: CordovaWebView) {
+        super.initialize(cordova, webView)
+        powerAuthStorageUtilsJsModule = PowerAuthStorageUtilsJsModule(cordova.context.applicationContext)
+    }
+
+    @Throws(JSONException::class)
+    override fun execute(action: String, args: JSONArray, callbackContext: CallbackContext): Boolean {
+        val promise = Promise(callbackContext)
+        when (action) {
+            "setString" -> {
+                setString(args, promise)
+                return true
+            }
+            "getString" -> {
+                getString(args, promise)
+                return true
+            }
+            "exists" -> {
+                exists(args, promise)
+                return true
+            }
+            "remove" -> {
+                remove(args, promise)
+                return true
+            }
+        }
+        return false
+    }
+
+    private fun setString(args: JSONArray, promise: Promise) {
+        val key = args.getString(0)
+        val value = args.getString(1)
+        val storageType = args.getString(2)
+        powerAuthStorageUtilsJsModule.setString(key, value, storageType, promise)
+    }
+
+    private fun getString(args: JSONArray, promise: Promise) {
+        val key = args.getString(0)
+        val storageType = args.getString(1)
+        powerAuthStorageUtilsJsModule.getString(key, storageType, promise)
+    }
+
+    private fun exists(args: JSONArray, promise: Promise) {
+        val key = args.getString(0)
+        val storageType = args.getString(1)
+        powerAuthStorageUtilsJsModule.exists(key, storageType, promise)
+    }
+
+    private fun remove(args: JSONArray, promise: Promise) {
+        val key = args.getString(0)
+        val storageType = args.getString(1)
+        powerAuthStorageUtilsJsModule.remove(key, storageType, promise)
+    }
+}

--- a/packages/cordova-powerauth-mobile-sdk/plugin.xml
+++ b/packages/cordova-powerauth-mobile-sdk/plugin.xml
@@ -33,6 +33,9 @@
             <feature name="PowerAuthCryptoUtilsModule">
                 <param name="android-package" value="com.wultra.android.powerauth.cordova.plugin.PowerAuthCryptoUtilsModule" />
             </feature>
+            <feature name="PowerAuthStorageUtilsModule">
+                <param name="android-package" value="com.wultra.android.powerauth.cordova.plugin.PowerAuthStorageUtilsModule" />
+            </feature>
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/*" />
         <source-file src="android/src/main/java/com/wultra/android/powerauth/cdv/PowerAuthModule.kt" target-dir="java/com/wultra/android/powerauth/cdv/" />
@@ -41,6 +44,7 @@
         <source-file src="android/src/main/java/com/wultra/android/powerauth/cdv/PowerAuthPasswordModule.kt" target-dir="java/com/wultra/android/powerauth/cdv/" />
         <source-file src="android/src/main/java/com/wultra/android/powerauth/cdv/PowerAuthEncryptorModule.kt" target-dir="java/com/wultra/android/powerauth/cdv/" />
         <source-file src="android/src/main/java/com/wultra/android/powerauth/cdv/PowerAuthCryptoUtilsModule.kt" target-dir="java/com/wultra/android/powerauth/cdv/" />
+        <source-file src="android/src/main/java/com/wultra/android/powerauth/cdv/PowerAuthStorageUtilsModule.kt" target-dir="java/com/wultra/android/powerauth/cdv/" />
 
         <source-file src="android/src/main/java/com/wultra/android/powerauth/bridge/Aliases.kt" target-dir="java/com/wultra/android/powerauth/bridge" />
         <source-file src="android/src/main/java/com/wultra/android/powerauth/bridge/Mappings.kt" target-dir="java/com/wultra/android/powerauth/bridge" />
@@ -74,6 +78,7 @@
         <source-file src="android/src/main/java/com/wultra/android/powerauth/js/PowerAuthPassphraseMeterJsModule.kt" target-dir="java/com/wultra/android/powerauth/js" />
         <source-file src="android/src/main/java/com/wultra/android/powerauth/js/PowerAuthPasswordJsModule.kt" target-dir="java/com/wultra/android/powerauth/js" />
         <source-file src="android/src/main/java/com/wultra/android/powerauth/js/PowerAuthCryptoUtilsJsModule.kt" target-dir="java/com/wultra/android/powerauth/js" />
+        <source-file src="android/src/main/java/com/wultra/android/powerauth/js/PowerAuthStorageUtilsJsModule.kt" target-dir="java/com/wultra/android/powerauth/js" />
         <source-file src="android/src/main/java/com/wultra/android/powerauth/js/ReleasePolicy.java" target-dir="com/wultra/android/powerauth/js" />
         <source-file src="android/src/main/java/com/wultra/android/powerauth/js/Utils.kt" target-dir="java/com/wultra/android/powerauth/js" />
         <source-file src="android/src/main/java/com/wultra/android/powerauth/js/WrapperException.java" target-dir="com/wultra/android/powerauth/js" />
@@ -101,6 +106,9 @@
             <feature name="PowerAuthCryptoUtilsModule">
                 <param name="ios-package" value="PowerAuthCryptoUtilsModule"/>
             </feature>
+            <feature name="PowerAuthStorageUtilsModule">
+                <param name="ios-package" value="PowerAuthStorageUtilsModule"/>
+            </feature>
             <preference name="deployment-target" value="12.0" />
             <preference name="UseSwiftLanguageVersion" value="5" />
         </config-file>
@@ -123,6 +131,8 @@
         <source-file src="ios/PowerAuth/PowerAuthPasswordModule.m" />
         <header-file src="ios/PowerAuth/PowerAuthCryptoUtilsModule.h" />
         <source-file src="ios/PowerAuth/PowerAuthCryptoUtilsModule.m" />
+        <header-file src="ios/PowerAuth/PowerAuthStorageUtilsModule.h" />
+        <source-file src="ios/PowerAuth/PowerAuthStorageUtilsModule.m" />
         <header-file src="ios/PowerAuth/Utilities.h" />
         <source-file src="ios/PowerAuth/Utilities.m" />
         <source-file src="ios/PowerAuth/pin_tester.c" />

--- a/packages/cordova-powerauth-mobile-sdk/src/internal/NativeModulesProvider.ts
+++ b/packages/cordova-powerauth-mobile-sdk/src/internal/NativeModulesProvider.ts
@@ -25,6 +25,7 @@ import { PowerAuthPasswordIfc } from "./NativePassword";
 import { NativeCordovaModule } from "./NativeCordovaModule";
 import { NativePowerAuth } from "./NativePowerAuth";
 import { PowerAuthCryptoUtilsIfc } from "./NativeCryptoUtils";
+import { PowerAuthStorageUtilsIfc } from "./NativeStorageUtils";
 
 class Provider implements NativeModulesProviderIfc {
     PowerAuthObjectRegister = new NativeObjectRegisterImpl() as NativeObjectRegisterIfc & NativeObject;
@@ -32,6 +33,7 @@ class Provider implements NativeModulesProviderIfc {
     PowerAuthPassphraseMeter = new PowerAuthPassphraseMeterImpl() as PowerAuthPassphraseMeterIfc;
     PowerAuthPassword = new PowerAuthPasswordImpl() as PowerAuthPasswordIfc;
     PowerAuthCryptoUtils = new PowerAuthCryptoUtilsImpl() as PowerAuthCryptoUtilsIfc;
+    PowerAuthStorageUtils = new PowerAuthStorageUtilsImpl() as PowerAuthStorageUtilsIfc;
     PowerAuth = new NativePowerAuth();
 }
 
@@ -141,6 +143,27 @@ class PowerAuthCryptoUtilsImpl extends NativeCordovaModule implements PowerAuthC
 
     async randomBytes(length: number): Promise<string> {
         return await this.callNative("randomBytes", [length]);
+    }
+}
+
+class PowerAuthStorageUtilsImpl extends NativeCordovaModule implements PowerAuthStorageUtilsIfc {
+
+    readonly pluginName = "PowerAuthStorageUtilsModule";
+
+    async setString(key: string, value: string, storageType: string): Promise<void> {
+        return await this.callNative("setString", [key, value, storageType]);
+    }
+
+    async getString(key: string, storageType: string): Promise<string | null> {
+        return await this.callNative("getString", [key, storageType]);
+    }
+
+    async exists(key: string, storageType: string): Promise<boolean> {
+        return await this.callNative("exists", [key, storageType]);
+    }
+
+    async remove(key: string, storageType: string): Promise<boolean> {
+        return await this.callNative("remove", [key, storageType]);
     }
 }
 

--- a/packages/react-native-powerauth-mobile-sdk/android/src/main/java/com/wultra/android/powerauth/js/PowerAuthStorageUtilsJsModule.kt
+++ b/packages/react-native-powerauth-mobile-sdk/android/src/main/java/com/wultra/android/powerauth/js/PowerAuthStorageUtilsJsModule.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.wultra.android.powerauth.js
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.wultra.android.powerauth.bridge.JsApiMethod
+import com.wultra.android.powerauth.bridge.Promise
+import io.getlime.security.powerauth.keychain.Keychain
+import io.getlime.security.powerauth.keychain.KeychainFactory
+import io.getlime.security.powerauth.keychain.KeychainProtection
+
+class PowerAuthStorageUtilsJsModule(
+    private val context: Context
+) : BaseJavaJsModule {
+
+    companion object {
+        private const val STORAGE_TYPE_SECURE = "SECURE"
+        private const val STORAGE_TYPE_STANDARD = "STANDARD"
+        private const val KEYCHAIN_IDENTIFIER = "com.wultra.powerauth.jssdk.storageutils.secure"
+        private const val PREFS_NAME_STANDARD = "com.wultra.powerauth.jssdk.storageutils.standard"
+    }
+
+    private var keychain: Keychain? = null
+    private var standardPrefs: SharedPreferences? = null
+
+    override fun getName(): String {
+        return "PowerAuthStorageUtils"
+    }
+
+    @JsApiMethod
+    fun setString(key: String, value: String, storageType: String, promise: Promise) {
+        try {
+            validateKey(key)
+
+            when (storageType) {
+                STORAGE_TYPE_SECURE -> {
+                    getKeychain().putString(value, key)
+                }
+                STORAGE_TYPE_STANDARD -> {
+                    getStandardPreferences().edit { putString(key, value) }
+                }
+                else -> throw WrapperException(Errors.EC_WRONG_PARAMETER, "Invalid storage type: $storageType")
+            }
+
+            promise.resolve(null)
+        } catch (t: Throwable) {
+            Errors.rejectPromise(promise, t)
+        }
+    }
+
+    @JsApiMethod
+    fun getString(key: String, storageType: String, promise: Promise) {
+        try {
+            validateKey(key)
+
+            val value = when (storageType) {
+                STORAGE_TYPE_SECURE -> {
+                    getKeychain().getString(key)
+                }
+                STORAGE_TYPE_STANDARD -> {
+                    getStandardPreferences().getString(key, null)
+                }
+                else -> throw WrapperException(Errors.EC_WRONG_PARAMETER, "Invalid storage type: $storageType")
+            }
+
+            promise.resolve(value)
+        } catch (t: Throwable) {
+            Errors.rejectPromise(promise, t)
+        }
+    }
+
+    @JsApiMethod
+    fun exists(key: String, storageType: String, promise: Promise) {
+        try {
+            validateKey(key)
+
+            val exists = when (storageType) {
+                STORAGE_TYPE_SECURE -> getKeychain().contains(key)
+                STORAGE_TYPE_STANDARD -> getStandardPreferences().contains(key)
+                else -> throw WrapperException(Errors.EC_WRONG_PARAMETER, "Invalid storage type: $storageType")
+            }
+
+            promise.resolve(exists)
+        } catch (t: Throwable) {
+            Errors.rejectPromise(promise, t)
+        }
+    }
+
+    @JsApiMethod
+    fun remove(key: String, storageType: String, promise: Promise) {
+        try {
+            validateKey(key)
+
+            val existed = when (storageType) {
+                STORAGE_TYPE_SECURE -> {
+                    val kc = getKeychain()
+                    val contains = kc.contains(key)
+                    kc.remove(key)
+
+                    contains
+                }
+                STORAGE_TYPE_STANDARD -> {
+                    val prefs = getStandardPreferences()
+                    val contains = prefs.contains(key)
+                    prefs.edit { remove(key) }
+
+                    contains
+                }
+                else -> throw WrapperException(Errors.EC_WRONG_PARAMETER, "Invalid storage type: $storageType")
+            }
+
+            promise.resolve(existed)
+        } catch (t: Throwable) {
+            Errors.rejectPromise(promise, t)
+        }
+    }
+
+    private fun validateKey(key: String) {
+        if (key.isEmpty()) {
+            throw WrapperException(Errors.EC_WRONG_PARAMETER, "Key cannot be empty")
+        }
+    }
+
+    private fun getKeychain(): Keychain {
+        if (keychain == null) {
+            keychain = KeychainFactory.getKeychain(context, KEYCHAIN_IDENTIFIER, KeychainProtection.NONE)
+        }
+
+        return keychain!!
+    }
+
+    private fun getStandardPreferences(): SharedPreferences {
+        if (standardPrefs == null) {
+            standardPrefs = context.getSharedPreferences(PREFS_NAME_STANDARD, Context.MODE_PRIVATE)
+        }
+
+        return standardPrefs!!
+    }
+}

--- a/packages/react-native-powerauth-mobile-sdk/android/src/main/java/com/wultra/android/powerauth/reactnative/PowerAuthReactPackage.java
+++ b/packages/react-native-powerauth-mobile-sdk/android/src/main/java/com/wultra/android/powerauth/reactnative/PowerAuthReactPackage.java
@@ -37,6 +37,7 @@ public class PowerAuthReactPackage implements ReactPackage {
         modules.add(new PowerAuthModule(reactContext, objectRegister, passwordModule));
         modules.add(new PowerAuthPassphraseMeterModule(passwordModule));
         modules.add(new PowerAuthCryptoUtilsModule());
+        modules.add(new PowerAuthStorageUtilsModule(reactContext));
         return modules;
     }
 }

--- a/packages/react-native-powerauth-mobile-sdk/android/src/main/java/com/wultra/android/powerauth/reactnative/PowerAuthStorageUtilsModule.java
+++ b/packages/react-native-powerauth-mobile-sdk/android/src/main/java/com/wultra/android/powerauth/reactnative/PowerAuthStorageUtilsModule.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wultra.android.powerauth.reactnative;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.module.annotations.ReactModule;
+import com.wultra.android.powerauth.js.PowerAuthStorageUtilsJsModule;
+
+@SuppressWarnings("unused")
+@ReactModule(name = "PowerAuthStorageUtils")
+public class PowerAuthStorageUtilsModule extends ReactContextBaseJavaModule {
+
+    private final PowerAuthStorageUtilsJsModule powerAuthStorageUtilsJsModule;
+
+    public PowerAuthStorageUtilsModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+        this.powerAuthStorageUtilsJsModule = new PowerAuthStorageUtilsJsModule(reactContext.getApplicationContext());
+    }
+
+    public PowerAuthStorageUtilsJsModule getPowerAuthStorageUtilsJsModule() {
+        return powerAuthStorageUtilsJsModule;
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return powerAuthStorageUtilsJsModule.getName();
+    }
+
+    @ReactMethod
+    void setString(String key, String value, String storageType, Promise promise) {
+        powerAuthStorageUtilsJsModule.setString(key, value, storageType, promise);
+    }
+
+    @ReactMethod
+    void getString(String key, String storageType, Promise promise) {
+        powerAuthStorageUtilsJsModule.getString(key, storageType, promise);
+    }
+
+    @ReactMethod
+    void exists(String key, String storageType, Promise promise) {
+        powerAuthStorageUtilsJsModule.exists(key, storageType, promise);
+    }
+
+    @ReactMethod
+    void remove(String key, String storageType, Promise promise) {
+        powerAuthStorageUtilsJsModule.remove(key, storageType, promise);
+    }
+}

--- a/packages/react-native-powerauth-mobile-sdk/ios/PowerAuth/PowerAuthStorageUtilsModule.h
+++ b/packages/react-native-powerauth-mobile-sdk/ios/PowerAuth/PowerAuthStorageUtilsModule.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "PAJS.h"
+
+PAJS_MODULE_BASIC(PowerAuthStorageUtilsModule)
+
+@end
+

--- a/packages/react-native-powerauth-mobile-sdk/ios/PowerAuth/PowerAuthStorageUtilsModule.m
+++ b/packages/react-native-powerauth-mobile-sdk/ios/PowerAuth/PowerAuthStorageUtilsModule.m
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "PowerAuthStorageUtilsModule.h"
+#import "Errors.h"
+#import <PowerAuth2/PowerAuthKeychain.h>
+
+static NSString * const kStorageTypeSecure = @"SECURE";
+static NSString * const kStorageTypeStandard = @"STANDARD";
+static NSString * const kKeychainServiceName = @"com.wultra.powerauth.jssdk.storageutils.secure";
+static NSString * const kUserDefaultsSuiteName = @"com.wultra.powerauth.jssdk.storageutils.standard";
+
+@implementation PowerAuthStorageUtilsModule
+{
+    PowerAuthKeychain * _keychain;
+    NSUserDefaults * _userDefaults;
+}
+
+RCT_EXPORT_MODULE(PowerAuthStorageUtils);
+
++ (BOOL) requiresMainQueueSetup
+{
+    return NO;
+}
+
+- (PowerAuthKeychain *)keychain
+{
+    if (!_keychain) {
+        _keychain = [[PowerAuthKeychain alloc] initWithIdentifier:kKeychainServiceName];
+    }
+    return _keychain;
+}
+
+- (NSUserDefaults *)userDefaults
+{
+    if (!_userDefaults) {
+        _userDefaults = [[NSUserDefaults alloc] initWithSuiteName:kUserDefaultsSuiteName];
+    }
+    return _userDefaults;
+}
+
+// MARK: - JS interface
+
+PAJS_METHOD_START(setString,
+                  PAJS_ARGUMENT(key, NSString*)
+                  PAJS_ARGUMENT(value, NSString*)
+                  PAJS_ARGUMENT(storageType, NSString*))
+{
+    NSString * keyStr = [RCTConvert NSString:key];
+    NSString * valueStr = [RCTConvert NSString:value];
+    NSString * storageTypeStr = [RCTConvert NSString:storageType];
+    
+    if (!keyStr || keyStr.length == 0) {
+        reject(EC_WRONG_PARAMETER, @"Key cannot be empty", nil);
+        return;
+    }
+    
+    if ([storageTypeStr isEqualToString:kStorageTypeSecure]) {
+        NSData * data = [valueStr dataUsingEncoding:NSUTF8StringEncoding];
+        PowerAuthKeychainStoreItemResult result = [[self keychain] addValue:data forKey:keyStr];
+
+        if (result == PowerAuthKeychainStoreItemResult_Ok) {
+            resolve([NSNull null]);
+        } else if (result == PowerAuthKeychainStoreItemResult_Duplicate) {
+            PowerAuthKeychainStoreItemResult updateResult = [[self keychain] updateValue:data forKey:keyStr];
+
+            if (updateResult == PowerAuthKeychainStoreItemResult_Ok) {
+                resolve([NSNull null]);
+            } else {
+                reject(EC_WRONG_PARAMETER, @"Failed to update value in Keychain", nil);
+            }
+        } else {
+            reject(EC_WRONG_PARAMETER, @"Failed to store value in Keychain", nil);
+        }
+    } else if ([storageTypeStr isEqualToString:kStorageTypeStandard]) {
+        [[self userDefaults] setObject:valueStr forKey:keyStr];
+        [[self userDefaults] synchronize];
+
+        resolve([NSNull null]);
+    } else {
+        reject(EC_WRONG_PARAMETER, @"Invalid storage type", nil);
+    }
+}
+PAJS_METHOD_END
+
+PAJS_METHOD_START(getString,
+                  PAJS_ARGUMENT(key, NSString*)
+                  PAJS_ARGUMENT(storageType, NSString*))
+{
+    NSString * keyStr = [RCTConvert NSString:key];
+    NSString * storageTypeStr = [RCTConvert NSString:storageType];
+    
+    if (!keyStr || keyStr.length == 0) {
+        reject(EC_WRONG_PARAMETER, @"Key cannot be empty", nil);
+        return;
+    }
+    
+    if ([storageTypeStr isEqualToString:kStorageTypeSecure]) {
+        NSData * data = [[self keychain] dataForKey:keyStr status:nil];
+        if (data) {
+            NSString * value = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+            resolve(value);
+        } else {
+            resolve([NSNull null]);
+        }
+    } else if ([storageTypeStr isEqualToString:kStorageTypeStandard]) {
+        NSString * value = [[self userDefaults] stringForKey:keyStr];
+
+        if (value) {
+            resolve(value);
+        } else {
+            resolve([NSNull null]);
+        }
+    } else {
+        reject(EC_WRONG_PARAMETER, @"Invalid storage type", nil);
+    }
+}
+PAJS_METHOD_END
+
+PAJS_METHOD_START(exists,
+                  PAJS_ARGUMENT(key, NSString*)
+                  PAJS_ARGUMENT(storageType, NSString*))
+{
+    NSString * keyStr = [RCTConvert NSString:key];
+    NSString * storageTypeStr = [RCTConvert NSString:storageType];
+    
+    if (!keyStr || keyStr.length == 0) {
+        reject(EC_WRONG_PARAMETER, @"Key cannot be empty", nil);
+        return;
+    }
+    
+    if ([storageTypeStr isEqualToString:kStorageTypeSecure]) {
+        BOOL exists = [[self keychain] containsDataForKey:keyStr];
+        resolve(@(exists));
+    } else if ([storageTypeStr isEqualToString:kStorageTypeStandard]) {
+        BOOL exists = [[self userDefaults] objectForKey:keyStr] != nil;
+        resolve(@(exists));
+    } else {
+        reject(EC_WRONG_PARAMETER, @"Invalid storage type", nil);
+    }
+}
+PAJS_METHOD_END
+
+PAJS_METHOD_START(remove,
+                  PAJS_ARGUMENT(key, NSString*)
+                  PAJS_ARGUMENT(storageType, NSString*))
+{
+    NSString * keyStr = [RCTConvert NSString:key];
+    NSString * storageTypeStr = [RCTConvert NSString:storageType];
+    
+    if (!keyStr || keyStr.length == 0) {
+        reject(EC_WRONG_PARAMETER, @"Key cannot be empty", nil);
+        return;
+    }
+    
+    if ([storageTypeStr isEqualToString:kStorageTypeSecure]) {
+        BOOL existed = [[self keychain] containsDataForKey:keyStr];
+        [[self keychain] deleteDataForKey:keyStr];
+
+        resolve(@(existed));
+    } else if ([storageTypeStr isEqualToString:kStorageTypeStandard]) {
+        BOOL existed = [[self userDefaults] objectForKey:keyStr] != nil;
+
+        [[self userDefaults] removeObjectForKey:keyStr];
+        [[self userDefaults] synchronize];
+
+        resolve(@(existed));
+    } else {
+        reject(EC_WRONG_PARAMETER, @"Invalid storage type", nil);
+    }
+}
+PAJS_METHOD_END
+
+@end

--- a/packages/react-native-powerauth-mobile-sdk/ios/PowerAuth/PowerAuthStorageUtilsModule.m
+++ b/packages/react-native-powerauth-mobile-sdk/ios/PowerAuth/PowerAuthStorageUtilsModule.m
@@ -80,10 +80,10 @@ PAJS_METHOD_START(setString,
             if (updateResult == PowerAuthKeychainStoreItemResult_Ok) {
                 resolve([NSNull null]);
             } else {
-                reject(EC_WRONG_PARAMETER, @"Failed to update value in Keychain", nil);
+                reject(EC_ENCRYPTION_ERROR, @"Failed to update value in Keychain", nil);
             }
         } else {
-            reject(EC_WRONG_PARAMETER, @"Failed to store value in Keychain", nil);
+            reject(EC_ENCRYPTION_ERROR, @"Failed to store value in Keychain", nil);
         }
     } else if ([storageTypeStr isEqualToString:kStorageTypeStandard]) {
         [[self userDefaults] setObject:valueStr forKey:keyStr];

--- a/packages/react-native-powerauth-mobile-sdk/src/PowerAuthStorageUtils.ts
+++ b/packages/react-native-powerauth-mobile-sdk/src/PowerAuthStorageUtils.ts
@@ -22,7 +22,7 @@ import { NativeStorageUtils } from "./internal/NativeStorageUtils";
  */
 export enum PowerAuthStorageType {
     /**
-     * Secure storage: Keychain (iOS) / EncryptedSharedPreferences (Android)
+     * Secure storage: PowerAuth Keychain (iOS & Android)
      */
     SECURE = "SECURE",
     /**
@@ -34,14 +34,6 @@ export enum PowerAuthStorageType {
 /**
  * The `PowerAuthStorageUtils` class provides utility methods for storing and retrieving
  * string values in platform-specific secure and standard storage.
- * 
- * On iOS:
- * - SECURE: Keychain
- * - STANDARD: UserDefaults
- * 
- * On Android:
- * - SECURE: EncryptedSharedPreferences
- * - STANDARD: SharedPreferences
  */
 export class PowerAuthStorageUtils {
 
@@ -106,4 +98,3 @@ export class PowerAuthStorageUtils {
         }
     }
 }
-

--- a/packages/react-native-powerauth-mobile-sdk/src/PowerAuthStorageUtils.ts
+++ b/packages/react-native-powerauth-mobile-sdk/src/PowerAuthStorageUtils.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NativeWrapper } from "./internal/NativeWrapper";
+import { NativeStorageUtils } from "./internal/NativeStorageUtils";
+
+/**
+ * Enum defining the type of storage to use.
+ */
+export enum PowerAuthStorageType {
+    /**
+     * Secure storage: Keychain (iOS) / EncryptedSharedPreferences (Android)
+     */
+    SECURE = "SECURE",
+    /**
+     * Standard storage: UserDefaults (iOS) / SharedPreferences (Android)
+     */
+    STANDARD = "STANDARD"
+}
+
+/**
+ * The `PowerAuthStorageUtils` class provides utility methods for storing and retrieving
+ * string values in platform-specific secure and standard storage.
+ * 
+ * On iOS:
+ * - SECURE: Keychain
+ * - STANDARD: UserDefaults
+ * 
+ * On Android:
+ * - SECURE: EncryptedSharedPreferences
+ * - STANDARD: SharedPreferences
+ */
+export class PowerAuthStorageUtils {
+
+    /**
+     * Stores a string value for the given key in the specified storage type.
+     * @param key The key to store the value under.
+     * @param value The string value to store.
+     * @param storageType The type of storage to use (SECURE or STANDARD).
+     * @throws `PowerAuthErrorCode.WRONG_PARAMETER` if key or value is invalid.
+     */
+    static async setString(key: string, value: string, storageType: PowerAuthStorageType): Promise<void> {
+        try {
+            return await NativeStorageUtils.setString(key, value, storageType);
+        } catch (error) {
+            throw NativeWrapper.processException(error);
+        }
+    }
+
+    /**
+     * Retrieves a string value for the given key from the specified storage type.
+     * @param key The key to retrieve the value for.
+     * @param storageType The type of storage to use (SECURE or STANDARD).
+     * @returns The stored string value, or undefined if the key does not exist.
+     * @throws `PowerAuthErrorCode.WRONG_PARAMETER` if key is invalid.
+     */
+    static async getString(key: string, storageType: PowerAuthStorageType): Promise<string | undefined> {
+        try {
+            const result = await NativeStorageUtils.getString(key, storageType);
+            return result ?? undefined;
+        } catch (error) {
+            throw NativeWrapper.processException(error);
+        }
+    }
+
+    /**
+     * Checks if a value exists for the given key in the specified storage type.
+     * @param key The key to check.
+     * @param storageType The type of storage to use (SECURE or STANDARD).
+     * @returns True if the key exists, false otherwise.
+     * @throws `PowerAuthErrorCode.WRONG_PARAMETER` if key is invalid.
+     */
+    static async exists(key: string, storageType: PowerAuthStorageType): Promise<boolean> {
+        try {
+            return await NativeStorageUtils.exists(key, storageType);
+        } catch (error) {
+            throw NativeWrapper.processException(error);
+        }
+    }
+
+    /**
+     * Removes the value for the given key from the specified storage type.
+     * @param key The key to remove.
+     * @param storageType The type of storage to use (SECURE or STANDARD).
+     * @returns True if the key was removed, false if the key did not exist.
+     * @throws `PowerAuthErrorCode.WRONG_PARAMETER` if key is invalid.
+     */
+    static async remove(key: string, storageType: PowerAuthStorageType): Promise<boolean> {
+        try {
+            return await NativeStorageUtils.remove(key, storageType);
+        } catch (error) {
+            throw NativeWrapper.processException(error);
+        }
+    }
+}
+

--- a/packages/react-native-powerauth-mobile-sdk/src/index.ts
+++ b/packages/react-native-powerauth-mobile-sdk/src/index.ts
@@ -22,6 +22,7 @@ export * from './PowerAuthUtils';
 export * from './PowerAuthTokenStore';
 export * from './PowerAuthPassphraseMeter';
 export * from './PowerAuthCryptoUtils';
+export * from './PowerAuthStorageUtils';
 
 // Model objects
 

--- a/packages/react-native-powerauth-mobile-sdk/src/internal/NativeModulesProvider.ts
+++ b/packages/react-native-powerauth-mobile-sdk/src/internal/NativeModulesProvider.ts
@@ -24,6 +24,7 @@ class Provider implements NativeModulesProviderIfc {
     PowerAuthPassphraseMeter = NativeModules.PowerAuthPassphraseMeter
     PowerAuthPassword = NativeModules.PowerAuthPassword
     PowerAuthCryptoUtils = NativeModules.PowerAuthCryptoUtils
+    PowerAuthStorageUtils = NativeModules.PowerAuthStorageUtils
     PowerAuth = new NativePowerAuth()
 }
 

--- a/packages/react-native-powerauth-mobile-sdk/src/internal/NativeModulesProviderIfc.ts
+++ b/packages/react-native-powerauth-mobile-sdk/src/internal/NativeModulesProviderIfc.ts
@@ -21,6 +21,7 @@ import { PowerAuthPassphraseMeterIfc } from "./NativePassphraseMeter";
 import { PowerAuthPasswordIfc } from "./NativePassword";
 import { NativePowerAuthIfc } from "./NativePowerAuthIfc";
 import { PowerAuthCryptoUtilsIfc } from "./NativeCryptoUtils";
+import { PowerAuthStorageUtilsIfc } from "./NativeStorageUtils";
 
 
 export interface NativeModulesProviderIfc {
@@ -29,5 +30,6 @@ export interface NativeModulesProviderIfc {
     PowerAuthPassphraseMeter: PowerAuthPassphraseMeterIfc;
     PowerAuthPassword: PowerAuthPasswordIfc;
     PowerAuthCryptoUtils: PowerAuthCryptoUtilsIfc;
+    PowerAuthStorageUtils: PowerAuthStorageUtilsIfc;
     PowerAuth: NativePowerAuthIfc;
 }

--- a/packages/react-native-powerauth-mobile-sdk/src/internal/NativeStorageUtils.ts
+++ b/packages/react-native-powerauth-mobile-sdk/src/internal/NativeStorageUtils.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NativeModulesProvider } from './NativeModulesProvider';
+
+export interface PowerAuthStorageUtilsIfc {
+    setString(key: string, value: string, storageType: string): Promise<void>
+    getString(key: string, storageType: string): Promise<string | null>
+    exists(key: string, storageType: string): Promise<boolean>
+    remove(key: string, storageType: string): Promise<boolean>
+}
+
+export const NativeStorageUtils = NativeModulesProvider.PowerAuthStorageUtils;
+

--- a/testapp/_tests/PowerAuth_StorageUtils.test.ts
+++ b/testapp/_tests/PowerAuth_StorageUtils.test.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2025 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestWithActivation } from "./helpers/TestWithActivation";
+
+import { PowerAuthStorageUtils, PowerAuthStorageType, PowerAuthErrorCode } from "react-native-powerauth-mobile-sdk";
+import { expect } from "../src/testbed";
+
+export class PowerAuth_StorageUtilsTest extends TestWithActivation {
+    override shouldCreateActivationBeforeTest(): boolean {
+        return false;
+    }
+
+    private uniqueKey(prefix: string): string {
+        return `${prefix}_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    }
+
+    async testSecureStorageSetAndGet() {
+        const key = this.uniqueKey("test_secure");
+        const value = "secure_value_123";
+
+        await PowerAuthStorageUtils.setString(key, value, PowerAuthStorageType.SECURE);
+
+        const retrieved = await PowerAuthStorageUtils.getString(key, PowerAuthStorageType.SECURE);
+        expect(retrieved).toBe(value);
+
+        await PowerAuthStorageUtils.remove(key, PowerAuthStorageType.SECURE);
+    }
+
+    async testStandardStorageSetAndGet() {
+        const key = this.uniqueKey("test_standard");
+        const value = "standard_value_456";
+
+        await PowerAuthStorageUtils.setString(key, value, PowerAuthStorageType.STANDARD);
+
+        const retrieved = await PowerAuthStorageUtils.getString(key, PowerAuthStorageType.STANDARD);
+        expect(retrieved).toBe(value);
+
+        await PowerAuthStorageUtils.remove(key, PowerAuthStorageType.STANDARD);
+    }
+
+    async testSecureStorageExists() {
+        const key = this.uniqueKey("test_exists_secure");
+        const value = "exists_test";
+
+        expect(await PowerAuthStorageUtils.exists(key, PowerAuthStorageType.SECURE)).toBe(false);
+
+        await PowerAuthStorageUtils.setString(key, value, PowerAuthStorageType.SECURE);
+
+        expect(await PowerAuthStorageUtils.exists(key, PowerAuthStorageType.SECURE)).toBe(true);
+
+        await PowerAuthStorageUtils.remove(key, PowerAuthStorageType.SECURE);
+    }
+
+    async testStandardStorageExists() {
+        const key = this.uniqueKey("test_exists_standard");
+        const value = "exists_test";
+
+        expect(await PowerAuthStorageUtils.exists(key, PowerAuthStorageType.STANDARD)).toBe(false);
+
+        await PowerAuthStorageUtils.setString(key, value, PowerAuthStorageType.STANDARD);
+
+        expect(await PowerAuthStorageUtils.exists(key, PowerAuthStorageType.STANDARD)).toBe(true);
+
+        await PowerAuthStorageUtils.remove(key, PowerAuthStorageType.STANDARD);
+    }
+
+    async testSecureStorageRemove() {
+        const key = this.uniqueKey("test_remove_secure");
+        const value = "remove_test";
+
+        await PowerAuthStorageUtils.setString(key, value, PowerAuthStorageType.SECURE);
+        expect(await PowerAuthStorageUtils.exists(key, PowerAuthStorageType.SECURE)).toBe(true);
+
+        const removed = await PowerAuthStorageUtils.remove(key, PowerAuthStorageType.SECURE);
+        expect(removed).toBe(true);
+
+        expect(await PowerAuthStorageUtils.exists(key, PowerAuthStorageType.SECURE)).toBe(false);
+
+        const removedAgain = await PowerAuthStorageUtils.remove(key, PowerAuthStorageType.SECURE);
+        expect(removedAgain).toBe(false);
+    }
+
+    async testStandardStorageRemove() {
+        const key = this.uniqueKey("test_remove_standard");
+        const value = "remove_test";
+
+        await PowerAuthStorageUtils.setString(key, value, PowerAuthStorageType.STANDARD);
+        expect(await PowerAuthStorageUtils.exists(key, PowerAuthStorageType.STANDARD)).toBe(true);
+
+        const removed = await PowerAuthStorageUtils.remove(key, PowerAuthStorageType.STANDARD);
+        expect(removed).toBe(true);
+
+        expect(await PowerAuthStorageUtils.exists(key, PowerAuthStorageType.STANDARD)).toBe(false);
+
+        const removedAgain = await PowerAuthStorageUtils.remove(key, PowerAuthStorageType.STANDARD);
+        expect(removedAgain).toBe(false);
+    }
+
+    async testGetNonExistentKey() {
+        const key = this.uniqueKey("non_existent");
+
+        const secureValue = await PowerAuthStorageUtils.getString(key, PowerAuthStorageType.SECURE);
+        expect(secureValue).toBe(undefined);
+
+        const standardValue = await PowerAuthStorageUtils.getString(key, PowerAuthStorageType.STANDARD);
+        expect(standardValue).toBe(undefined);
+    }
+
+
+    async testEmptyStringValue() {
+        const key = this.uniqueKey("test_empty");
+        const emptyValue = "";
+
+        await PowerAuthStorageUtils.setString(key, emptyValue, PowerAuthStorageType.SECURE);
+        
+        expect(await PowerAuthStorageUtils.exists(key, PowerAuthStorageType.SECURE)).toBe(true);
+        
+        expect(await PowerAuthStorageUtils.getString(key, PowerAuthStorageType.SECURE)).toBe(emptyValue);
+
+        await PowerAuthStorageUtils.remove(key, PowerAuthStorageType.SECURE);
+    }
+
+    async testJsonValue() {
+        const key = this.uniqueKey("test_json");
+        const jsonObject = { name: "test", value: 123, nested: { array: [1, 2, 3] } };
+        const jsonValue = JSON.stringify(jsonObject);
+
+        await PowerAuthStorageUtils.setString(key, jsonValue, PowerAuthStorageType.SECURE);
+
+        const retrieved = await PowerAuthStorageUtils.getString(key, PowerAuthStorageType.SECURE);
+        expect(retrieved).toBe(jsonValue);
+        
+        const parsed = JSON.parse(retrieved!);
+        expect(parsed.name).toBe("test");
+        expect(parsed.value).toBe(123);
+        expect(parsed.nested.array.length).toBe(3);
+
+        await PowerAuthStorageUtils.remove(key, PowerAuthStorageType.SECURE);
+    }
+
+    async testEmptyKeyFails() {
+        await expect(async () => {
+            await PowerAuthStorageUtils.setString("", "value", PowerAuthStorageType.SECURE);
+        }).toThrow({ errorCode: PowerAuthErrorCode.WRONG_PARAMETER });
+
+        await expect(async () => {
+            await PowerAuthStorageUtils.getString("", PowerAuthStorageType.SECURE);
+        }).toThrow({ errorCode: PowerAuthErrorCode.WRONG_PARAMETER });
+
+        await expect(async () => {
+            await PowerAuthStorageUtils.exists("", PowerAuthStorageType.SECURE);
+        }).toThrow({ errorCode: PowerAuthErrorCode.WRONG_PARAMETER });
+
+        await expect(async () => {
+            await PowerAuthStorageUtils.remove("", PowerAuthStorageType.SECURE);
+        }).toThrow({ errorCode: PowerAuthErrorCode.WRONG_PARAMETER });
+    }
+
+}

--- a/testapp/_tests/PowerAuth_StorageUtils.test.ts
+++ b/testapp/_tests/PowerAuth_StorageUtils.test.ts
@@ -142,6 +142,7 @@ export class PowerAuth_StorageUtilsTest extends TestWithActivation {
         await PowerAuthStorageUtils.setString(key, jsonValue, PowerAuthStorageType.SECURE);
 
         const retrieved = await PowerAuthStorageUtils.getString(key, PowerAuthStorageType.SECURE);
+
         expect(retrieved).toBe(jsonValue);
         
         const parsed = JSON.parse(retrieved!);
@@ -170,4 +171,62 @@ export class PowerAuth_StorageUtilsTest extends TestWithActivation {
         }).toThrow({ errorCode: PowerAuthErrorCode.WRONG_PARAMETER });
     }
 
+    async testStorageTypesIsolation() {
+        const key = this.uniqueKey("test_isolation");
+
+        const secureValue = "secure_isolation_test";
+        const standardValue = "standard_isolation_test";
+
+        await PowerAuthStorageUtils.setString(key, secureValue, PowerAuthStorageType.SECURE);
+        await PowerAuthStorageUtils.setString(key, standardValue, PowerAuthStorageType.STANDARD);
+
+        expect(await PowerAuthStorageUtils.getString(key, PowerAuthStorageType.SECURE)).toBe(secureValue);
+        expect(await PowerAuthStorageUtils.getString(key, PowerAuthStorageType.STANDARD)).toBe(standardValue);
+
+        await PowerAuthStorageUtils.remove(key, PowerAuthStorageType.SECURE);
+        expect(await PowerAuthStorageUtils.exists(key, PowerAuthStorageType.SECURE)).toBe(false);
+        expect(await PowerAuthStorageUtils.exists(key, PowerAuthStorageType.STANDARD)).toBe(true);
+
+        await PowerAuthStorageUtils.remove(key, PowerAuthStorageType.STANDARD);
+    }
+
+    async testLongValue() {
+        const key = this.uniqueKey("test_long");
+        const longValue = "x".repeat(10 * 1024);
+
+        await PowerAuthStorageUtils.setString(key, longValue, PowerAuthStorageType.SECURE);
+
+        const value = await PowerAuthStorageUtils.getString(key, PowerAuthStorageType.SECURE);
+        expect(value).toBe(longValue);
+        expect(value!.length).toBe(10 * 1024);
+
+        await PowerAuthStorageUtils.remove(key, PowerAuthStorageType.SECURE);
+    }
+
+    async testOverwriteValue() {
+        const key = this.uniqueKey("test_overwrite");
+        const value1 = "first_value";
+        const value2 = "second_value";
+
+        await PowerAuthStorageUtils.setString(key, value1, PowerAuthStorageType.SECURE);
+        expect(await PowerAuthStorageUtils.getString(key, PowerAuthStorageType.SECURE)).toBe(value1);
+
+        await PowerAuthStorageUtils.setString(key, value2, PowerAuthStorageType.SECURE);
+        expect(await PowerAuthStorageUtils.getString(key, PowerAuthStorageType.SECURE)).toBe(value2);
+
+        await PowerAuthStorageUtils.remove(key, PowerAuthStorageType.SECURE);
+    }
+
+    async testUnicodeValues() {
+        const key = this.uniqueKey("test_unicode");
+        const unicodeValue = "Test 🌍 ñ č ř ž";
+
+        await PowerAuthStorageUtils.setString(key, unicodeValue, PowerAuthStorageType.SECURE);
+        expect(await PowerAuthStorageUtils.getString(key, PowerAuthStorageType.SECURE)).toBe(unicodeValue);
+        await PowerAuthStorageUtils.remove(key, PowerAuthStorageType.SECURE);
+
+        await PowerAuthStorageUtils.setString(key, unicodeValue, PowerAuthStorageType.STANDARD);
+        expect(await PowerAuthStorageUtils.getString(key, PowerAuthStorageType.STANDARD)).toBe(unicodeValue);
+        await PowerAuthStorageUtils.remove(key, PowerAuthStorageType.STANDARD);
+    }
 }

--- a/testapp/_tests/PowerAuth_StorageUtils.test.ts
+++ b/testapp/_tests/PowerAuth_StorageUtils.test.ts
@@ -25,7 +25,7 @@ export class PowerAuth_StorageUtilsTest extends TestWithActivation {
     }
 
     private uniqueKey(prefix: string): string {
-        return `${prefix}_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+        return `${prefix}_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
     }
 
     async testSecureStorageSetAndGet() {

--- a/testapp/ios/Podfile.lock
+++ b/testapp/ios/Podfile.lock
@@ -5,9 +5,9 @@ PODS:
   - FBLazyVector (0.78.1)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - hermes-engine (0.78.0):
-    - hermes-engine/Pre-built (= 0.78.0)
-  - hermes-engine/Pre-built (0.78.0)
+  - hermes-engine (0.78.1):
+    - hermes-engine/Pre-built (= 0.78.1)
+  - hermes-engine/Pre-built (0.78.1)
   - PowerAuth2 (1.9.5):
     - PowerAuthCore (~> 1.9.5)
   - PowerAuthCore (1.9.5)
@@ -1780,8 +1780,8 @@ SPEC CHECKSUMS:
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: bba368dacede4c9dec7a58c9be5a2d3e9ea30cc7
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
-  glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: b417d2b2aee3b89b58e63e23a51e02be91dc876d
+  glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
+  hermes-engine: f493b0a600aed5dc06532141603688a30a5b2f61
   PowerAuth2: 8ce9b05ad8ce12157c521d0112d6c7e755ea755d
   PowerAuthCore: 2bd5e5b2fa4de392436413238441b586465f428b
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82


### PR DESCRIPTION
Closes #304 .

This PR implements a minimal API for string key-value storing from the TS layer on both RN and Cordova.
It wraps `UserDefaults` and `SharedPreferences`, and `PowerAuth`'s `Keychain` iOS and Android API for secure value storage.