### PR TITLE
fix: Cordova error unwrapping and passing

### DIFF
--- a/packages/cordova-powerauth-mobile-sdk/android/src/main/java/com/wultra/android/powerauth/cdv/util/Promise.kt
+++ b/packages/cordova-powerauth-mobile-sdk/android/src/main/java/com/wultra/android/powerauth/cdv/util/Promise.kt
@@ -65,7 +65,7 @@ class Promise(
    * @param throwable Throwable
    */
   fun reject(code: String, message: String?, throwable: Throwable?) {
-    callbackContext.error(buildErrorJson(code, message ?: throwable?.message, null))
+    callbackContext.error(buildErrorJson(code, message?.takeIf { it.isNotEmpty() } ?: throwable?.message, null))
   }
 
   /**
@@ -134,6 +134,6 @@ class Promise(
    * @param userInfo WritableMap
    */
   fun reject(code: String?, message: String?, throwable: Throwable?, userInfo: WritableMap?) {
-    callbackContext.error(buildErrorJson(code, message ?: throwable?.message, userInfo))
+    callbackContext.error(buildErrorJson(code, message?.takeIf { it.isNotEmpty() } ?: throwable?.message, userInfo))
   }
 }

--- a/packages/cordova-powerauth-mobile-sdk/android/src/main/java/com/wultra/android/powerauth/cdv/util/Promise.kt
+++ b/packages/cordova-powerauth-mobile-sdk/android/src/main/java/com/wultra/android/powerauth/cdv/util/Promise.kt
@@ -29,12 +29,11 @@ class Promise(
   }
 
   private fun buildErrorJson(code: String?, message: String?, userInfo: WritableMap?): JSONObject {
-    val m = mutableMapOf<String, Any?>()
-
-    code?.let { m["code"] = it }
-    message?.let { m["message"] = it }
+    val m = mutableMapOf<String, Any?>(
+      "code" to code,
+      "message" to message
+    )
     userInfo?.let { m["userInfo"] = it.toHashMap() }
-
     return JSONObject(m.toMap())
   }
 

--- a/packages/cordova-powerauth-mobile-sdk/android/src/main/java/com/wultra/android/powerauth/cdv/util/Promise.kt
+++ b/packages/cordova-powerauth-mobile-sdk/android/src/main/java/com/wultra/android/powerauth/cdv/util/Promise.kt
@@ -28,6 +28,16 @@ class Promise(
     }
   }
 
+  private fun buildErrorJson(code: String?, message: String?, userInfo: WritableMap?): JSONObject {
+    val m = mutableMapOf<String, Any?>()
+
+    code?.let { m["code"] = it }
+    message?.let { m["message"] = it }
+    userInfo?.let { m["userInfo"] = it.toHashMap() }
+
+    return JSONObject(m.toMap())
+  }
+
   /**
    * Report an error without an exception using a custom code and error message.
    *
@@ -35,8 +45,7 @@ class Promise(
    * @param message String
    */
   fun reject(code: String, message: String?) {
-    val m = mapOf("code" to code, "message" to message)
-    callbackContext.error(JSONObject(m))
+    callbackContext.error(buildErrorJson(code, message, null))
   }
 
   /**
@@ -46,8 +55,7 @@ class Promise(
    * @param throwable Throwable
    */
   fun reject(code: String, throwable: Throwable?) {
-    val m = mapOf("code" to code, "throwable" to throwable)
-    callbackContext.error(JSONObject(m))
+    callbackContext.error(buildErrorJson(code, throwable?.message, null))
   }
 
   /**
@@ -58,8 +66,7 @@ class Promise(
    * @param throwable Throwable
    */
   fun reject(code: String, message: String?, throwable: Throwable?) {
-    val m = mapOf("code" to code, "message" to message, "throwable" to throwable)
-    callbackContext.error(JSONObject(m))
+    callbackContext.error(buildErrorJson(code, message ?: throwable?.message, null))
   }
 
   /**
@@ -69,8 +76,7 @@ class Promise(
    * @param throwable Throwable
    */
   fun reject(throwable: Throwable) {
-    val m = mapOf("throwable" to throwable)
-    callbackContext.error(JSONObject(m))
+    callbackContext.error(buildErrorJson(null, throwable.message, null))
   }
 
   /* ---------------------------
@@ -84,8 +90,7 @@ class Promise(
    * @param userInfo WritableMap
    */
   fun reject(throwable: Throwable, userInfo: WritableMap) {
-    val m = mapOf("throwable" to throwable, "userInfo" to JSONObject(userInfo.toHashMap().toMap()))
-    callbackContext.error(JSONObject(m))
+    callbackContext.error(buildErrorJson(null, throwable.message, userInfo))
   }
 
   /**
@@ -95,8 +100,7 @@ class Promise(
    * @param userInfo WritableMap
    */
   fun reject(code: String, userInfo: WritableMap) {
-    val m = mapOf("code" to code, "userInfo" to JSONObject(userInfo.toHashMap().toMap()))
-    callbackContext.error(JSONObject(m))
+    callbackContext.error(buildErrorJson(code, null, userInfo))
   }
 
   /**
@@ -107,8 +111,7 @@ class Promise(
    * @param userInfo WritableMap
    */
   fun reject(code: String, throwable: Throwable?, userInfo: WritableMap) {
-    val m = mapOf("code" to code, "throwable" to throwable, "userInfo" to JSONObject(userInfo.toHashMap().toMap()))
-    callbackContext.error(JSONObject(m))
+    callbackContext.error(buildErrorJson(code, throwable?.message, userInfo))
   }
 
   /**
@@ -120,8 +123,7 @@ class Promise(
    * @param userInfo WritableMap
    */
   fun reject(code: String, message: String?, userInfo: WritableMap) {
-    val m = mapOf("code" to code, "message" to message, "userInfo" to JSONObject(userInfo.toHashMap().toMap()))
-    callbackContext.error(JSONObject(m))
+    callbackContext.error(buildErrorJson(code, message, userInfo))
   }
 
   /**
@@ -133,10 +135,6 @@ class Promise(
    * @param userInfo WritableMap
    */
   fun reject(code: String?, message: String?, throwable: Throwable?, userInfo: WritableMap?) {
-    val m = mutableMapOf("code" to code, "message" to message, "throwable" to throwable)
-    userInfo?.let { 
-      m["userInfo"] = userInfo.toHashMap()
-    }
-    callbackContext.error(JSONObject(m.toMap()))
+    callbackContext.error(buildErrorJson(code, message ?: throwable?.message, userInfo))
   }
 }

--- a/packages/react-native-powerauth-mobile-sdk/ios/PowerAuth/PAJS.h
+++ b/packages/react-native-powerauth-mobile-sdk/ios/PowerAuth/PAJS.h
@@ -88,13 +88,13 @@ typedef void (^RCTPromiseResolveBlock)(id result);
     parameters \
     RCTPromiseRejectBlock reject = ^(NSString *code, NSString *message, NSError *error) { \
         NSError *writeError = nil; \
-        NSDictionary *userInfo = [error userInfo]; \
+        NSDictionary *userInfo = error ? [error userInfo] : nil; \
         NSMutableDictionary *errorDict = [NSMutableDictionary dictionaryWithDictionary:@{ @"code": code ? code : [NSNull null], @"message": message ? message: [NSNull null] }]; \
         if (userInfo && [NSJSONSerialization isValidJSONObject:userInfo]) { \
             errorDict[@"userInfo"] = userInfo; \
         } \
         NSData *jsonData = [NSJSONSerialization dataWithJSONObject:errorDict options:NSJSONWritingPrettyPrinted error:&writeError]; \
-        NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];   \
+        NSString *jsonString = jsonData ? [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding] : @"{\"code\":\"SERIALIZATION_ERROR\",\"message\":\"Failed to serialize error\"}"; \
         [[self commandDelegate] sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:jsonString] callbackId: cmd.callbackId]; \
     }; \
     RCTPromiseResolveBlock resolve = ^(id result) { \
@@ -109,13 +109,13 @@ typedef void (^RCTPromiseResolveBlock)(id result);
 { \
     RCTPromiseRejectBlock reject = ^(NSString *code, NSString *message, NSError *error) { \
         NSError *writeError = nil; \
-        NSDictionary *userInfo = [error userInfo]; \
+        NSDictionary *userInfo = error ? [error userInfo] : nil; \
         NSMutableDictionary *errorDict = [NSMutableDictionary dictionaryWithDictionary:@{ @"code": code ? code : [NSNull null], @"message": message ? message: [NSNull null] }]; \
         if (userInfo && [NSJSONSerialization isValidJSONObject:userInfo]) { \
             errorDict[@"userInfo"] = userInfo; \
         } \
         NSData *jsonData = [NSJSONSerialization dataWithJSONObject:errorDict options:NSJSONWritingPrettyPrinted error:&writeError]; \
-        NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];   \
+        NSString *jsonString = jsonData ? [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding] : @"{\"code\":\"SERIALIZATION_ERROR\",\"message\":\"Failed to serialize error\"}"; \
         [[self commandDelegate] sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:jsonString] callbackId: cmd.callbackId]; \
     }; \
     RCTPromiseResolveBlock resolve = ^(id result) { \

--- a/packages/react-native-powerauth-mobile-sdk/ios/PowerAuth/PAJS.h
+++ b/packages/react-native-powerauth-mobile-sdk/ios/PowerAuth/PAJS.h
@@ -88,7 +88,12 @@ typedef void (^RCTPromiseResolveBlock)(id result);
     parameters \
     RCTPromiseRejectBlock reject = ^(NSString *code, NSString *message, NSError *error) { \
         NSError *writeError = nil; \
-        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:@{ @"code": code ? code : [NSNull null], @"message": message ? message: [NSNull null] } options:NSJSONWritingPrettyPrinted error:&writeError]; \
+        NSDictionary *userInfo = [error userInfo]; \
+        NSMutableDictionary *errorDict = [NSMutableDictionary dictionaryWithDictionary:@{ @"code": code ? code : [NSNull null], @"message": message ? message: [NSNull null] }]; \
+        if (userInfo && [NSJSONSerialization isValidJSONObject:userInfo]) { \
+            errorDict[@"userInfo"] = userInfo; \
+        } \
+        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:errorDict options:NSJSONWritingPrettyPrinted error:&writeError]; \
         NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];   \
         [[self commandDelegate] sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:jsonString] callbackId: cmd.callbackId]; \
     }; \
@@ -104,7 +109,12 @@ typedef void (^RCTPromiseResolveBlock)(id result);
 { \
     RCTPromiseRejectBlock reject = ^(NSString *code, NSString *message, NSError *error) { \
         NSError *writeError = nil; \
-        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:@{ @"code": code ? code : [NSNull null], @"message": message ? message: [NSNull null] } options:NSJSONWritingPrettyPrinted error:&writeError]; \
+        NSDictionary *userInfo = [error userInfo]; \
+        NSMutableDictionary *errorDict = [NSMutableDictionary dictionaryWithDictionary:@{ @"code": code ? code : [NSNull null], @"message": message ? message: [NSNull null] }]; \
+        if (userInfo && [NSJSONSerialization isValidJSONObject:userInfo]) { \
+            errorDict[@"userInfo"] = userInfo; \
+        } \
+        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:errorDict options:NSJSONWritingPrettyPrinted error:&writeError]; \
         NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];   \
         [[self commandDelegate] sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:jsonString] callbackId: cmd.callbackId]; \
     }; \

--- a/testapp/_tests/AllTests.ts
+++ b/testapp/_tests/AllTests.ts
@@ -38,6 +38,7 @@ import { PowerAuth_RecoveryTests } from "./PowerAuth_Recovery.test";
 import { PowerAuth_TimeSyncTests } from "./PowerAuth_TimeSync.test";
 import { PowerAuth_UserInfoTest } from "./PowerAuth_UserInfo.test";
 import { PowerAuth_CryptoUtilsTest } from "./PowerAuth_CryptoUtils.test";
+import { PowerAuth_ErrorDataTests } from "./PowerAuth_ErrorData.test";
 
 export function getLibraryTests(): TestSuite[] {
     return [
@@ -60,7 +61,8 @@ export function getLibraryTests(): TestSuite[] {
         new PowerAuth_UserInfoTest(),
         new PowerAuth_LegacyAuthTests(),
         new NativeObjectRegisterTests(),
-        new PowerAuth_CryptoUtilsTest()
+        new PowerAuth_CryptoUtilsTest(),
+        new PowerAuth_ErrorDataTests()
     ]
 }
 

--- a/testapp/_tests/PowerAuth_ErrorData.test.ts
+++ b/testapp/_tests/PowerAuth_ErrorData.test.ts
@@ -1,0 +1,50 @@
+//
+// Copyright 2025 Wultra s.r.o.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { PowerAuthError, PowerAuthErrorCode } from "react-native-powerauth-mobile-sdk";
+import { expect } from "../src/testbed";
+import { TestWithActivation } from "./helpers/TestWithActivation";
+
+export class PowerAuth_ErrorDataTests extends TestWithActivation {
+
+    async testErrorContainsParsedData() {
+        try {
+            await this.sdk.validatePassword(this.credentials.invalidPassword)
+        } catch (e) {
+            expect(e instanceof PowerAuthError).toBe(true)
+            const error = e as PowerAuthError
+
+            expect(error.code).toBe(PowerAuthErrorCode.AUTHENTICATION_ERROR)
+            expect(error.errorData).toBeDefined()
+            expect(typeof error.errorData.httpStatusCode).toBe('number')
+            expect(error.errorData.httpStatusCode).toBe(401)
+            expect(typeof error.errorData.responseBody).toBe('string')
+        }
+    }
+
+    async testResponseErrorContainsParsedData() {
+        try {
+            await this.sdk.confirmRecoveryCode('AAAAA-AAAAA-AAAAA-AAAAA', this.credentials.knowledge)
+        } catch (e) {
+            expect(e instanceof PowerAuthError).toBe(true)
+            const error = e as PowerAuthError
+
+            expect(error.code === PowerAuthErrorCode.RESPONSE_ERROR || error.code === PowerAuthErrorCode.AUTHENTICATION_ERROR).toBe(true)
+            expect(error.errorData).toBeDefined()
+            expect(typeof error.errorData.httpStatusCode).toBe('number')
+        }
+    }
+}

--- a/testapp/_tests/PowerAuth_ErrorData.test.ts
+++ b/testapp/_tests/PowerAuth_ErrorData.test.ts
@@ -21,9 +21,11 @@ import { TestWithActivation } from "./helpers/TestWithActivation";
 export class PowerAuth_ErrorDataTests extends TestWithActivation {
 
     async testErrorContainsParsedData() {
+        let errorThrown = false
         try {
             await this.sdk.validatePassword(this.credentials.invalidPassword)
         } catch (e) {
+            errorThrown = true
             expect(e instanceof PowerAuthError).toBe(true)
             const error = e as PowerAuthError
 
@@ -33,12 +35,15 @@ export class PowerAuth_ErrorDataTests extends TestWithActivation {
             expect(error.errorData.httpStatusCode).toBe(401)
             expect(typeof error.errorData.responseBody).toBe('string')
         }
+        expect(errorThrown).toBe(true)
     }
 
     async testResponseErrorContainsParsedData() {
+        let errorThrown = false
         try {
             await this.sdk.confirmRecoveryCode('AAAAA-AAAAA-AAAAA-AAAAA', this.credentials.knowledge)
         } catch (e) {
+            errorThrown = true
             expect(e instanceof PowerAuthError).toBe(true)
             const error = e as PowerAuthError
 
@@ -46,5 +51,6 @@ export class PowerAuth_ErrorDataTests extends TestWithActivation {
             expect(error.errorData).toBeDefined()
             expect(typeof error.errorData.httpStatusCode).toBe('number')
         }
+        expect(errorThrown).toBe(true)
     }
 }


### PR DESCRIPTION
Fixes #302 .

This PR implements specific fixes for both `iOS` (the PAJS macros) and `Android` (throwable unwrapping in Promise.kt).
I also added small sanity check tests, we can discuss whether they're necessary:).