### PR TITLE
Release preparation

### DIFF
--- a/.prepare-release.json
+++ b/.prepare-release.json
@@ -1,0 +1,43 @@
+{
+    "metadata": {
+        "purpose": "This file is used as a definition file for the prepare-release script.",
+        "info": "It defines files that contains version number that should be updated during the release preparation.",
+        "customBuildscript": "If needed, in the library object, set \"buildscript\": \"your-custom-build-command\" command if your build command is different than 'npm i && npm run build'"
+    },
+    "library": {
+        "name": "digital-onboarding-js",
+        "type": "yarn",
+        "artifacts": [
+            "packages/cordova-powerauth-mobile-sdk/build/cdv/cordova-powerauth-mobile-sdk-%VERSION%.tgz",
+            "packages/react-native-powerauth-mobile-sdk/react-native-powerauth-mobile-sdk-%VERSION%.tgz"
+        ],
+        "buildscript": "corepack enable && yarn install && yarn packReactNative && yarn build:cdv"
+    },
+    "files": [
+        {
+            "description": "React package definition file.",
+            "path": "packages/react-native-powerauth-mobile-sdk/package.json",
+            "type": "version_replace",
+            "match": "\"version\": \"%VERSION%\",\n",
+            "_comment": "Based on this version, all other versions are derived during the build."
+        },
+        {
+            "description": "Changelog",
+            "path": "docs/Changelog.md",
+            "type": "version_verify",
+            "match": "## %VERSION%"
+        },
+        {
+            "description": "Compatibility in the documentation.",
+            "path": "docs/Readme.md",
+            "type": "versionstream_verify",
+            "match": "| `%VERSION_STREAM%`"
+        },
+        {
+            "description": "Compatibility in the documentation.",
+            "path": "README.md",
+            "type": "versionstream_verify",
+            "match": "| `%VERSION_STREAM%`"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 [![Build](https://github.com/wultra/react-native-powerauth-mobile-sdk/actions/workflows/build-react-native.yml/badge.svg)](https://github.com/wultra/react-native-powerauth-mobile-sdk/actions/workflows/build-react-native.yml)
 
 
-
 In order to connect to the [PowerAuth](https://www.wultra.com/mobile-security-suite) service, mobile applications need to perform the required network and cryptographic processes, as described in the PowerAuth documentation. To simplify the implementation of these processes, developers can use This PowerAuth JS SDK library (for Android and iOS) from this repository.
 
 > [!NOTE]
@@ -25,7 +24,7 @@ The documentation is available at the [Wultra Developer Portal](https://develope
 | Version | React-Native<sup>1</sup> | Cordova   | Native SDK   | Server version | Support Status    |
 |---------|--------------------------|-----------|--------------|----------------|-------------------|
 | `4.1.x` | `0.73+`                  | `12.0.0+` | `1.9.x`      | `1.9+`         | Fully supported   |
-| `3.2.x` | `0.73+`                  | `12.0.0+` | `1.7.x`      | `0.24+`        | Bugfixes          |
+| `3.2.x` | `0.73+`                  | `12.0.0+` | `1.7.x`      | `0.24+`        | Security fixes    |
 | `4.0.x` | `0.73+`                  | `12.0.0+` | `1.9.x`      | `1.9+`         | Not supported     |
 | `3.1.x` | `0.73+`                  | `12.0.0+` | `1.7.x`      | `0.24+`        | Not supported     |
 | `3.0.x` | `0.73+`                  | `12.0.0+` | `1.7.x`      | `0.24+`        | Not supported     |
@@ -35,7 +34,7 @@ The documentation is available at the [Wultra Developer Portal](https://develope
 | `2.2.x` |                          | -         | `1.6.x`      | `0.24+`        | Not supported     |
 
 <!-- begin box info -->
-> Note 1: The library may also work with other React-Native versions but we don't guarantee compatibility. The specified version is the version that we use for the development and for the tests.
+> Note 1: The library may also work with other React-Native versions, but we don't guarantee compatibility. The specified version is the version that we use for the development and for the tests.
 <!-- end -->
 
 ## License

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -41,7 +41,7 @@ We currently support __REACT NATIVE__ and __APACHE CORDOVA__ development platfor
 | Version | React-Native<sup>1</sup> | Cordova   | Native SDK   | Server version | Support Status    |
 |---------|--------------------------|-----------|--------------|----------------|-------------------|
 | `4.1.x` | `0.73+`                  | `12.0.0+` | `1.9.x`      | `1.9+`         | Fully supported   |
-| `3.2.x` | `0.73+`                  | `12.0.0+` | `1.7.x`      | `0.24+`        | Bugfixes          |
+| `3.2.x` | `0.73+`                  | `12.0.0+` | `1.7.x`      | `0.24+`        | Security fixes    |
 | `4.0.x` | `0.73+`                  | `12.0.0+` | `1.9.x`      | `1.9+`         | Not supported     |
 | `3.1.x` | `0.73+`                  | `12.0.0+` | `1.7.x`      | `0.24+`        | Not supported     |
 | `3.0.x` | `0.73+`                  | `12.0.0+` | `1.7.x`      | `0.24+`        | Not supported     |

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e # stop script when error occurs
+set -u # stop when undefined variable is used
+#set -x # print all execution (good for debugging)
+
+######### USAGE #########
+#
+# To prepare or verify release metadata of the library (settings proper version, updating changelog, etc.)
+# - this script runs the JavaScript script from Wultra infrastructure repository
+# - it uses data defined in `.prepare-release.json` file in the root of the repository
+# - it passes all parameters to the JavaScript script
+#
+#
+# It can be run in 3 modes:
+#
+# 1. With a version (-v X.Y.Z) argument:
+#  - it will prepare the release with the current version
+#  - use it when you're preparing a new release pull-request
+#  - Example: sh scripts/prepare-release.sh -v 1.0.0
+#
+# 2. With a version argument and --verify:
+#  - it will verify that the given release version is prepared.
+#  - use it to make sure that the release pull-request is properly prepared (also used on CI)
+#  - Example: sh scripts/prepare-release.sh -v 1.0.0 --verify
+#
+# 3. Without arguments:
+#  - it will run the script in the root directory of the repository and verify that all files are prepared.
+#  - use it to make sure that the current state of the repository is ready for release
+#  - Example: sh scripts/prepare-release.sh
+#
+# Note: you can add --ignore-git-clean to ignore "git clean" errors (useful when testing things locally)
+#
+#########################
+
+# path to the script folder
+SCRIPT_FOLDER=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+# URL of the JavaScript prepare-release script in Wultra infrastructure repository
+URL="https://raw.githubusercontent.com/wultra/wultra-infrastructure/refs/heads/mobile-release/mobile-release/v1/prepare-release.js"
+
+# execute the remote node and pass all parameters to it + add path parameter to the root of the repository
+curl -fsSL "${URL}" | node - -p "${SCRIPT_FOLDER}/.." "${@}"


### PR DESCRIPTION
Fixes #254 

- adds `.prepare-release.json` definition file and `scripts/prepare-release.sh` script
- moved back the `README.md` file

The script was tested in a release-dry run on the CI pipeline...