### PR TITLE
ci: cache mobile dependencies and iOS compilation

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -17,6 +17,18 @@ runs:
       - name: Enable Yarn 
         shell: bash
         run: corepack enable
+      - name: Configure Yarn download cache
+        id: yarn-cache
+        shell: bash
+        run: |
+          echo "YARN_ENABLE_GLOBAL_CACHE=false" >> "$GITHUB_ENV"
+          echo "YARN_CACHE_FOLDER=$RUNNER_TEMP/yarn-cache" >> "$GITHUB_ENV"
+          echo "version=$(yarn --version)" >> "$GITHUB_OUTPUT"
+      - name: Restore Yarn downloads
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/yarn-cache
+          key: pa-ci-v3-${{ runner.os }}-${{ runner.arch }}-yarn-${{ steps.yarn-cache.outputs.version }}-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
       - name: Install dependencies (Yarn)
         shell: bash
         run: yarn install --immutable

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -197,6 +197,10 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 90
     env:
+      USE_CCACHE: "1"
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_MAXSIZE: "1G"
+      CCACHE_COMPILERCHECK: content
       E2E_COLLECTOR_TIMEOUT: "90m"
       E2E_RUN_START_TIMEOUT_SEC: "5400"
       E2E_COMPLETE_TIMEOUT_SEC: "5400"
@@ -233,20 +237,48 @@ jobs:
         with:
           env-file: ${{ secrets.ENV_TEST_FILE }}
 
+      - &setup-ruby
+        name: Set up Ruby gems
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4.1"
+          bundler-cache: true
+          working-directory: testapp
+
       - name: Detect Xcode version
         run: |
-          echo "XCODE_VERSION=$(xcodebuild -version | head -n 1 | awk '{print $2}')" >> $GITHUB_ENV
+          xcodebuild -version | awk '/^Build version/ { print "XCODE_VERSION=" $3 }' >> "$GITHUB_ENV"
 
-      - name: Cache CocoaPods downloads (RN)
+      - name: Cache prepared CocoaPods (RN)
         uses: actions/cache@v4
         with:
           path: |
-            ~/Library/Caches/CocoaPods
-            ~/.cocoapods
-          key: ${{ runner.os }}-e2e-ios-rn-cocoapods-v1-xcode${{ env.XCODE_VERSION }}-${{ hashFiles('testapp/ios/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-e2e-ios-rn-cocoapods-v1-
-            ${{ runner.os }}-e2e-ios-cocoapods-v1-
+            testapp/ios/Pods
+            testapp/ios/build/generated/ios
+          # Restore dependencies, then let pod install reconcile local sources and codegen.
+          key: pa-ci-v3-${{ runner.os }}-${{ runner.arch }}-pods-rn-installed-v1-xcode${{ env.XCODE_VERSION }}-${{ hashFiles('yarn.lock', '.yarnrc.yml', 'package.json', 'testapp/Gemfile*', 'testapp/ios/Podfile*', 'testapp/package.json', 'testapp/react-native.config.js', 'packages/lib-rn/package.json', 'packages/lib-rn/react-native.config.js', 'packages/lib-rn/*.podspec') }}
+
+      - name: Set up compiler cache
+        working-directory: ${{ runner.temp }}
+        run: |
+          curl -fsSLO https://github.com/ccache/ccache/releases/download/v4.14/ccache-4.14-darwin.tar.gz
+          echo "353a81ea8680d93387102cfde288ebed381a54272cfdc18224f241add6332b39  ccache-4.14-darwin.tar.gz" | shasum -a 256 -c -
+          tar -xzf ccache-4.14-darwin.tar.gz
+          echo "$RUNNER_TEMP/ccache-4.14-darwin" >> "$GITHUB_PATH"
+          echo "CCACHE_VERSION=4.14" >> "$GITHUB_ENV"
+          echo "CCACHE_DIR=$RUNNER_TEMP/ccache" >> "$GITHUB_ENV"
+
+      - name: Restore compiler cache (RN)
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          # ccache validates native edits; stable keys avoid uploading for tiny SDK changes.
+          key: pa-ci-v3-${{ runner.os }}-${{ runner.arch }}-ccache-rn-xcode${{ env.XCODE_VERSION }}-ccache${{ env.CCACHE_VERSION }}-${{ hashFiles('yarn.lock', 'testapp/ios/Podfile.lock', 'testapp/ios/Podfile', 'testapp/Gemfile.lock', 'scripts/ci/ios-compiler-cache.sh', 'packages/lib-rn/*.podspec', 'testapp/ios/testapp.xcodeproj/project.pbxproj') }}
+          # ccache versions can hash identical compiler inputs differently.
+          restore-keys: pa-ci-v3-${{ runner.os }}-${{ runner.arch }}-ccache-rn-xcode${{ env.XCODE_VERSION }}-ccache${{ env.CCACHE_VERSION }}-
+
+      - name: Reset compiler cache statistics
+        run: ccache --zero-stats
 
       - name: Build test infra packages
         run: |
@@ -258,6 +290,10 @@ jobs:
         env:
           E2E_MODE: rn
         run: bash scripts/e2e/run-ios-ci.sh
+
+      - name: Report compiler cache statistics
+        if: always()
+        run: ccache --show-stats && ccache --show-compression
 
       - name: Upload artifacts
         if: always()
@@ -312,9 +348,18 @@ jobs:
         with:
           env-file: ${{ secrets.ENV_TEST_FILE }}
 
+      - *setup-ruby
+
       - name: Detect Xcode version
         run: |
-          echo "XCODE_VERSION=$(xcodebuild -version | head -n 1 | awk '{print $2}')" >> $GITHUB_ENV
+          xcodebuild -version | awk '/^Build version/ { print "XCODE_VERSION=" $3 }' >> "$GITHUB_ENV"
+
+      - name: Cache CocoaPods downloads (Cordova)
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/CocoaPods
+          # PowerAuth prepares native frameworks in the download cache.
+          key: pa-ci-v3-${{ runner.os }}-${{ runner.arch }}-pods-cordova-xcode${{ env.XCODE_VERSION }}-${{ hashFiles('testapp/Gemfile.lock', 'packages/lib-cordova/plugin.xml', 'testapp-cordova/config.xml', 'testapp-cordova/package.json', 'yarn.lock') }}
 
       - name: Build test infra packages
         run: |
@@ -325,7 +370,8 @@ jobs:
       - name: Run E2E (iOS simulator, Cordova)
         env:
           E2E_MODE: cordova
-        run: bash scripts/e2e/run-ios-ci.sh
+          BUNDLE_GEMFILE: ${{ github.workspace }}/testapp/Gemfile
+        run: bundle exec bash scripts/e2e/run-ios-ci.sh
 
       - name: Upload artifacts
         if: always()

--- a/packages/lib-cordova/plugin.xml
+++ b/packages/lib-cordova/plugin.xml
@@ -148,7 +148,7 @@
 
         <podspec>
             <config>
-                <source url="https://github.com/CocoaPods/Specs.git"/>
+                <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods use-frameworks="true">
                 <pod name="PowerAuth2" options="'1.9.5'" />

--- a/scripts/ci/ios-compiler-cache.sh
+++ b/scripts/ci/ios-compiler-cache.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Shared by the iOS E2E build and the cache benchmark.
+
+configure_rn_compiler_cache() {
+  if [ "${USE_CCACHE:-0}" != "1" ]; then
+    return 0
+  fi
+
+  local ccache_binary cache_dir wrapper_dir compiler compiler_path
+  ccache_binary="$(command -v ccache)" || {
+    echo "[e2e] ERROR: USE_CCACHE=1 requires ccache to be installed."
+    return 1
+  }
+  cache_dir="${CCACHE_DIR:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/ccache}"
+  wrapper_dir="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/powerauth-rn-compilers"
+  mkdir -p "${wrapper_dir}"
+
+  # Compiler tasks do not reliably inherit custom Xcode build settings or shell
+  # variables. Bake the cache configuration into wrappers, with shell escaping.
+  for compiler in clang clang++; do
+    compiler_path="$(xcrun --find "${compiler}")"
+    {
+      echo '#!/usr/bin/env bash'
+      # RNCConfig imports GeneratedDotEnv.m, which embeds the test credentials.
+      # Compile it normally so those objects never enter the uploaded cache.
+      echo 'for argument in "$@"; do'
+      # Expanded by the generated wrapper, not by this setup script.
+      # shellcheck disable=SC2016
+      echo '  case "$argument" in'
+      echo '    */react-native-config/*|*/react-native-config.build/*|*GeneratedDotEnv*|*GeneratedInfoPlistDotEnv*)'
+      printf '      exec %q "$@" ;;\n' "${compiler_path}"
+      echo '  esac'
+      echo 'done'
+      printf 'export CCACHE_DIR=%q\n' "${cache_dir}"
+      printf 'export CCACHE_BASEDIR=%q\n' "${CCACHE_BASEDIR:-${PWD}}"
+      printf 'export CCACHE_MAXSIZE=%q\n' "${CCACHE_MAXSIZE:-1G}"
+      printf 'export CCACHE_COMPILERCHECK=%q\n' "${CCACHE_COMPILERCHECK:-content}"
+      printf 'export CCACHE_CONFIGPATH=%q\n' "${PWD}/testapp/node_modules/react-native/scripts/xcode/ccache.conf"
+      printf 'exec %q %q "$@"\n' "${ccache_binary}" "${compiler_path}"
+    } > "${wrapper_dir}/${compiler}"
+    chmod +x "${wrapper_dir}/${compiler}"
+  done
+
+  RN_BUILD_SETTINGS+=(
+    "CC=${wrapper_dir}/clang" "CXX=${wrapper_dir}/clang++"
+    "LD=${wrapper_dir}/clang" "LDPLUSPLUS=${wrapper_dir}/clang++"
+  )
+  echo "[e2e] Using compiler cache: ${cache_dir}"
+}

--- a/scripts/e2e/run-ios-ci.sh
+++ b/scripts/e2e/run-ios-ci.sh
@@ -175,16 +175,6 @@ abort_with_logs() {
 }
 
 install_rn_pods() {
-  echo "[e2e] Installing RN iOS Ruby gems..."
-  if ! command -v bundle >/dev/null 2>&1; then
-    echo "[e2e] Installing Bundler..."
-    gem install bundler -v 2.6.2
-  fi
-
-  if ! (cd testapp && bundle check); then
-    (cd testapp && bundle install)
-  fi
-
   echo "[e2e] Installing RN iOS CocoaPods..."
   (
     cd testapp/ios
@@ -194,6 +184,9 @@ install_rn_pods() {
       bundle exec pod install --repo-update --verbose
   )
 }
+
+# shellcheck source=scripts/ci/ios-compiler-cache.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../ci/ios-compiler-cache.sh"
 
 install_and_launch_rn_app() {
   app_path="$1"
@@ -327,7 +320,10 @@ if [ "${MODE}" = "rn" ] || [ "${MODE}" = "full" ]; then
     abort_with_logs
   fi
 
-  RN_DERIVED_DATA_PATH="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/powerauth-rn-ios.XXXXXX")"
+  # Keep compiler paths stable across fresh runners; DerivedData is never cached.
+  RN_DERIVED_DATA_PATH="${E2E_RN_DERIVED_DATA_PATH:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/powerauth-rn-ios}"
+  RN_BUILD_SETTINGS=("ARCHS=$(uname -m)")
+  configure_rn_compiler_cache
   echo "[e2e] Building RN iOS app for simulator ${SIM_ID}..."
   if ! xcodebuild \
     -workspace testapp/ios/testapp.xcworkspace \
@@ -335,6 +331,8 @@ if [ "${MODE}" = "rn" ] || [ "${MODE}" = "full" ]; then
     -configuration Debug \
     -destination "id=${SIM_ID}" \
     -derivedDataPath "${RN_DERIVED_DATA_PATH}" \
+    -showBuildTimingSummary \
+    "${RN_BUILD_SETTINGS[@]}" \
     build; then
     echo "[e2e] ERROR: Failed to build the RN iOS app."
     abort_with_logs

--- a/testapp-cordova/gulpfile.js
+++ b/testapp-cordova/gulpfile.js
@@ -18,7 +18,7 @@ const gulp = require("gulp");
 const replace = require('gulp-replace');
 const { build } = require("esbuild");
 const { rimraf } = require('rimraf'); // folder cleaner
-const exec = require('child_process').exec;
+const { exec, spawn } = require('child_process');
 const dotenv = require('dotenv');
 const fs = require('fs');
 
@@ -71,7 +71,7 @@ const compile = () =>
     })
 
 // to make sure all files are copied in the proper place
-const prepareIOS = () => exec("npx cordova prepare ios")
+const prepareIOS = () => spawn('npx', ['cordova', 'prepare', 'ios', '--verbose'], { stdio: 'inherit' })
 const prepareAndroid = () => exec("npx cordova prepare android")
 
 // patch testapp files


### PR DESCRIPTION
Mobile CI repeatedly downloads dependencies and recompiles unchanged iOS sources. Cache Yarn downloads, Ruby gems, prepared React Native Pods, Cordova CocoaPods downloads, and React Native compiler results using dependency-based keys. CocoaPods still reconciles local sources on every run; ccache validates changed compiler inputs and excludes dotenv-derived objects. GitHub manages cache retention.

Based on #442 (`upgrade-react-native-0.87`), before the PQA migration stack. This PR contains only the six-file caching change and preserves the base branch’s simulator behavior.

Validation on this base in disposable local checkouts:
- RN iOS: cold Pods/build 61.09s/123.58s; warm 7.52s/15.82s with 809/809 compiler hits and empty DerivedData.
- Native edit and fresh rerun: 808/809 hits; binary marker verified. Revert restored 809/809 hits and removed the marker.
- JavaScript edits appeared in fresh Metro bundles; rerun output matched and reverting restored the original bundle.
- Cordova: cold preparation 30.27s; preparation after restoring only the archived download cache 2.05s. Both native simulator builds passed.
- Three focused cache tests, ShellCheck, shell/JavaScript syntax, YAML parsing, and diff checks passed.

Local compressed cache estimates: RN Pods 201 MiB, compiler cache 103 MiB, Cordova downloads 10 MiB. Hosted runner timing and backend E2E on this rebased version remain to be confirmed; local timings exclude those stages.
